### PR TITLE
[SPOT-33][OA] Fix for Network context module fails when there is an empty string at the end of the file

### DIFF
--- a/spot-oa/oa/components/nc/network_context.py
+++ b/spot-oa/oa/components/nc/network_context.py
@@ -23,7 +23,8 @@ class NetworkContext(object):
 				csv_reader = csv.reader(nc_file)
 				csv_reader.next()
 				nc_rows = list(csv_reader)
-				self._nc_dict = dict([(x[0],x[1]) for x in nc_rows])
+				if len(nc_rows) > 0:
+					self._nc_dict = dict([(x[0], x[1]) if len(x) > 2 else ("-", "-") for x in nc_rows])
     
 	def get_nc(self, key):
 		if key in self._nc_dict:


### PR DESCRIPTION
Added validation to check if network_context lines are empty or if there are no lines at all.
Also, checks if the line contains at least 2 columns to create a dictionary, if there are 1 or fewer columns then the returned value is ("-","-").

[SPOT-33](https://issues.apache.org/jira/browse/SPOT-33)