### PR TITLE
[Spot-43][ML] Job count at InvalidDataHandler.scala:43 taking too long.

### DIFF
--- a/spot-ml/src/main/scala/org/apache/spot/lda/SpotLDAWrapper.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/lda/SpotLDAWrapper.scala
@@ -61,9 +61,6 @@ object SpotLDAWrapper {
       .toDF(DocumentName, DocumentNumber)
       .cache
 
-    // Forcing an action to cache results
-    documentDictionary.count()
-
     //Structure corpus so that the index is the docID, values are the vectors of word occurrences in that doc
     val ldaCorpus: RDD[(Long, Vector)] =
       formatSparkLDAInput(docWordCountCache,
@@ -148,7 +145,6 @@ object SpotLDAWrapper {
     val wordCountsPerDoc: RDD[(Long, Iterable[(Int, Double)])]
     = wordCountsPerDocDF
       .select(DocumentNumber, WordNumber, WordNameWordCount)
-      .rdd
       .map({ case Row(documentId: Long, wordId: Int, wordCount: Int) => (documentId.toLong, (wordId, wordCount.toDouble)) })
       .groupByKey
 

--- a/spot-ml/src/main/scala/org/apache/spot/netflow/FlowSuspiciousConnectsAnalysis.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/netflow/FlowSuspiciousConnectsAnalysis.scala
@@ -28,9 +28,6 @@ object FlowSuspiciousConnectsAnalysis {
 
     val scoredFlowRecords = detectFlowAnomalies(cleanFlowRecords, config, sparkContext, sqlContext, logger)
 
-    val corruptFlowRecords = filterAndSelectCorruptFlowRecords(scoredFlowRecords)
-    dataValidation.showAndSaveCorruptRecords(corruptFlowRecords, config.hdfsScoredConnect, logger)
-
     val filteredFlowRecords = filterScoredFlowRecords(scoredFlowRecords, config.threshold)
 
     val orderedFlowRecords = filteredFlowRecords.orderBy(Score)

--- a/spot-ml/src/main/scala/org/apache/spot/netflow/FlowSuspiciousConnectsAnalysis.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/netflow/FlowSuspiciousConnectsAnalysis.scala
@@ -28,6 +28,9 @@ object FlowSuspiciousConnectsAnalysis {
 
     val scoredFlowRecords = detectFlowAnomalies(cleanFlowRecords, config, sparkContext, sqlContext, logger)
 
+    val corruptFlowRecords = filterAndSelectCorruptFlowRecords(scoredFlowRecords)
+    dataValidation.showAndSaveCorruptRecords(corruptFlowRecords, config.hdfsScoredConnect, logger)
+
     val filteredFlowRecords = filterScoredFlowRecords(scoredFlowRecords, config.threshold)
 
     val orderedFlowRecords = filteredFlowRecords.orderBy(Score)
@@ -44,8 +47,6 @@ object FlowSuspiciousConnectsAnalysis {
     val invalidFlowRecords = filterAndSelectInvalidFlowRecords(inputFlowRecords)
     dataValidation.showAndSaveInvalidRecords(invalidFlowRecords, config.hdfsScoredConnect, logger)
 
-    val corruptFlowRecords = filterAndSelectCorruptFlowRecords(scoredFlowRecords)
-    dataValidation.showAndSaveCorruptRecords(corruptFlowRecords, config.hdfsScoredConnect, logger)
   }
 
   /**

--- a/spot-ml/src/main/scala/org/apache/spot/netflow/model/FlowSuspiciousConnectsModel.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/netflow/model/FlowSuspiciousConnectsModel.scala
@@ -202,6 +202,7 @@ object FlowSuspiciousConnectsModel {
     dataWithWords.cache()
     dataWithWords.count
 
+    // Save corrupt records, those records that failed to create the words
     val corruptRecords = dataWithWords
       .filter(dataWithWords(SourceWord) === InvalidDataHandler.WordError ||
         dataWithWords(DestinationWord) === InvalidDataHandler.WordError)

--- a/spot-ml/src/main/scala/org/apache/spot/netflow/model/FlowSuspiciousConnectsModel.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/netflow/model/FlowSuspiciousConnectsModel.scala
@@ -199,6 +199,15 @@ object FlowSuspiciousConnectsModel {
     val dataWithWords = totalRecords.withColumn(SourceWord, flowWordCreator.srcWordUDF(ModelColumns: _*))
       .withColumn(DestinationWord, flowWordCreator.dstWordUDF(ModelColumns: _*))
 
+    dataWithWords.cache()
+    dataWithWords.count
+
+    val corruptRecords = dataWithWords
+      .filter(dataWithWords(SourceWord) === InvalidDataHandler.WordError ||
+        dataWithWords(DestinationWord) === InvalidDataHandler.WordError)
+
+    InvalidDataHandler.showAndSaveCorruptRecords(corruptRecords, config.hdfsScoredConnect, logger)
+
     // Aggregate per-word counts at each IP
     val srcWordCounts = dataWithWords
       .filter(dataWithWords(SourceWord).notEqual(InvalidDataHandler.WordError))


### PR DESCRIPTION
Changed the place to call InvalidDataHandler.scala for flow suspicious connects analysis. 
This way, the function `showAndSaveCorruptRecords` won't try to filter `scoredFlowRecords` instead it will filter `dataWithWords` in FlowSuspiciousConnectsMode.scala.

Also removing the line from SpotLDAWrapper, documentDictionary.count() since it showed to be taking a long time as well. 

Tested with these changes and time was reduced from 11 hours to 7. 
More about this issue and steps to reproduce in Jira: https://issues.apache.org/jira/browse/SPOT-43 