### PR TITLE
Reverting changes in flows Edge notebook

### DIFF
--- a/spot-oa/oa/flow/ipynb_templates/Edge_Investigation_master.ipynb
+++ b/spot-oa/oa/flow/ipynb_templates/Edge_Investigation_master.ipynb
@@ -1,10 +1,8 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
     "Initialize workflow."
    ]


### PR DESCRIPTION
A typo committed in an previous PR was causing the Edge notebook to crash when it tried to execute a Markup cell as if it were code. 

Closes the bug: https://issues.apache.org/jira/browse/SPOT-139