### PR TITLE
SPOT-153 [ML] Feature improvement on proxy and elimination of quantiles

### DIFF
--- a/spot-ml/src/main/scala/org/apache/spot/proxy/ProxySuspiciousConnectsModel.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/proxy/ProxySuspiciousConnectsModel.scala
@@ -138,7 +138,7 @@ object ProxySuspiciousConnectsModel {
 
     val docWordCount: RDD[SpotLDAInput] =
       getIPWordCounts(sparkContext, sqlContext, logger, selectedRecords, config.feedbackFile, config.duplicationFactor,
-        agentToCount, EntropyCuts)
+        agentToCount)
 
 
     val SpotLDAOutput(ipToTopicMixDF, wordResults) = SpotLDAWrapper.runLDA(sparkContext,
@@ -180,14 +180,13 @@ object ProxySuspiciousConnectsModel {
                       inputRecords: DataFrame,
                       feedbackFile: String,
                       duplicationFactor: Int,
-                      agentToCount: Map[String, Long],
-                      entropyCuts: Array[Double]): RDD[SpotLDAInput] = {
+                      agentToCount: Map[String, Long]): RDD[SpotLDAInput] = {
 
 
     logger.info("Read source data")
     val selectedRecords = inputRecords.select(Date, Time, ClientIP, Host, ReqMethod, UserAgent, ResponseContentType, RespCode, FullURI)
 
-    val wc = ipWordCountFromDF(sc, selectedRecords, agentToCount, entropyCuts)
+    val wc = ipWordCountFromDF(sc, selectedRecords, agentToCount)
     logger.info("proxy pre LDA completed")
 
     wc
@@ -195,8 +194,7 @@ object ProxySuspiciousConnectsModel {
 
   def ipWordCountFromDF(sc: SparkContext,
                         dataFrame: DataFrame,
-                        agentToCount: Map[String, Long],
-                        entropyCuts: Array[Double]): RDD[SpotLDAInput] = {
+                        agentToCount: Map[String, Long]): RDD[SpotLDAInput] = {
 
     val topDomains: Broadcast[Set[String]] = sc.broadcast(TopDomains.TopDomains)
 

--- a/spot-ml/src/main/scala/org/apache/spot/proxy/ProxySuspiciousConnectsModel.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/proxy/ProxySuspiciousConnectsModel.scala
@@ -31,24 +31,18 @@ import org.apache.spot.proxy.ProxySchema._
 import org.apache.spot.utilities._
 import org.apache.spot.utilities.data.validation.InvalidDataHandler
 
-import scala.util.{Failure, Success, Try}
-
 /**
   * Encapsulation of a proxy suspicious connections model.
   *
   * @param topicCount         Number of "topics" used to cluster IPs and proxy "words" in the topic modelling analysis.
   * @param ipToTopicMIx       Maps each IP to a vector measuring Prob[ topic | this IP] for each topic.
   * @param wordToPerTopicProb Maps each word to a vector measuring Prob[word | topic] for each topic.
-  * @param timeCuts           Decile cutoffs for time-of-day in seconds.
-  * @param entropyCuts        Quintile cutoffs for measurement of full URI string entropy.
-  * @param agentCuts          Quintiile cutoffs for frequency of user agent.
+  * @param entropyCuts        Fixed cutoffs for measurement of full URI string entropy.
   */
 class ProxySuspiciousConnectsModel(topicCount: Int,
                                    ipToTopicMIx: Map[String, Array[Double]],
                                    wordToPerTopicProb: Map[String, Array[Double]],
-                                   timeCuts: Array[Double],
-                                   entropyCuts: Array[Double],
-                                   agentCuts: Array[Double]) {
+                                   entropyCuts: Array[Double]) {
 
   /**
     * Calculate suspicious connection scores for an incoming dataframe using this proxy suspicious connects model.
@@ -68,7 +62,7 @@ class ProxySuspiciousConnectsModel(topicCount: Int,
     val agentToCountBC = sc.broadcast(agentToCount)
 
     val udfWordCreation =
-      ProxyWordCreation.udfWordCreation(topDomains, agentToCountBC, timeCuts, entropyCuts, agentCuts)
+      ProxyWordCreation.udfWordCreation(topDomains, agentToCountBC, entropyCuts)
 
     val wordedDataFrame = dataFrame.withColumn(Word,
       udfWordCreation(dataFrame(Host),
@@ -118,35 +112,20 @@ object ProxySuspiciousConnectsModel {
     logger.info("training new proxy suspcious connects model")
 
 
-    val selectedRecords = inputRecords.select(Date, Time, ClientIP, Host, ReqMethod, UserAgent, ResponseContentType, RespCode, FullURI)
+    val selectedRecords =
+      inputRecords.select(Date, Time, ClientIP, Host, ReqMethod, UserAgent, ResponseContentType, RespCode, FullURI)
       .unionAll(ProxyFeedback.loadFeedbackDF(sparkContext, sqlContext, config.feedbackFile, config.duplicationFactor))
 
-    val timeCuts =
-      Quantiles.computeDeciles(selectedRecords
-        .select(Time)
-        .rdd
-        .flatMap({ case Row(t: String) =>
-          Try {
-            TimeUtilities.getTimeAsDouble(t)
-          } match {
-            case Failure(_) => Seq()
-            case Success(time) => Seq(time)
-
-          }
-        }))
-
-    val entropyCuts = Quantiles.computeQuintiles(selectedRecords
-      .select(FullURI)
-      .rdd
-      .flatMap({ case Row(uri: String) =>
-        Try {
-          Entropy.stringEntropy(uri)
-        } match {
-          case Failure(_) => Seq()
-          case Success(entropy) => Seq(entropy)
-        }
-
-      }))
+    // These buckets are optimized to datasets used for training. Last bucket is of larger size to ensure fit.
+    // The maximum value of entropy is given by log k where k is the number of distinct categories.
+    // Given that the alphabet and number of characters is finite the maximum value for entropy is upper bounded.
+    // Assuming 10,000 distinct categories the entropy is bounded by 13.38. Empirical tests showed a maximum
+    // value of 6.2 in our training set.
+    // Bucket number and size can be changed to provide less/more granularity
+    val entropyCuts = Array(0.0, 0.3, 0.6, 0.9, 1.2,
+      1.5, 1.8, 2.1, 2.4, 2.7,
+      3.0, 3.3, 3.6, 3.9, 4.2,
+      4.5, 4.8, 5.1, 5.4, 20)
 
     val agentToCount: Map[String, Long] =
       selectedRecords.select(UserAgent)
@@ -157,14 +136,11 @@ object ProxySuspiciousConnectsModel {
 
     val agentToCountBC = sparkContext.broadcast(agentToCount)
 
-    val agentCuts =
-      Quantiles.computeQuintiles(selectedRecords
-        .select(UserAgent)
-        .rdd
-        .map({ case Row(agent: String) => agentToCountBC.value(agent) }))
+
 
     val docWordCount: RDD[SpotLDAInput] =
-      getIPWordCounts(sparkContext, sqlContext, logger, selectedRecords, config.feedbackFile, config.duplicationFactor, agentToCount, timeCuts, entropyCuts, agentCuts)
+      getIPWordCounts(sparkContext, sqlContext, logger, selectedRecords, config.feedbackFile, config.duplicationFactor,
+        agentToCount, entropyCuts)
 
 
     val SpotLDAOutput(ipToTopicMixDF, wordResults) = SpotLDAWrapper.runLDA(sparkContext,
@@ -190,7 +166,7 @@ object ProxySuspiciousConnectsModel {
       .toMap
 
 
-    new ProxySuspiciousConnectsModel(config.topicCount, ipToTopicMix, wordResults, timeCuts, entropyCuts, agentCuts)
+    new ProxySuspiciousConnectsModel(config.topicCount, ipToTopicMix, wordResults, entropyCuts)
 
   }
 
@@ -207,15 +183,13 @@ object ProxySuspiciousConnectsModel {
                       feedbackFile: String,
                       duplicationFactor: Int,
                       agentToCount: Map[String, Long],
-                      timeCuts: Array[Double],
-                      entropyCuts: Array[Double],
-                      agentCuts: Array[Double]): RDD[SpotLDAInput] = {
+                      entropyCuts: Array[Double]): RDD[SpotLDAInput] = {
 
 
     logger.info("Read source data")
     val selectedRecords = inputRecords.select(Date, Time, ClientIP, Host, ReqMethod, UserAgent, ResponseContentType, RespCode, FullURI)
 
-    val wc = ipWordCountFromDF(sc, selectedRecords, agentToCount, timeCuts, entropyCuts, agentCuts)
+    val wc = ipWordCountFromDF(sc, selectedRecords, agentToCount, entropyCuts)
     logger.info("proxy pre LDA completed")
 
     wc
@@ -224,14 +198,12 @@ object ProxySuspiciousConnectsModel {
   def ipWordCountFromDF(sc: SparkContext,
                         dataFrame: DataFrame,
                         agentToCount: Map[String, Long],
-                        timeCuts: Array[Double],
-                        entropyCuts: Array[Double],
-                        agentCuts: Array[Double]): RDD[SpotLDAInput] = {
+                        entropyCuts: Array[Double]): RDD[SpotLDAInput] = {
 
     val topDomains: Broadcast[Set[String]] = sc.broadcast(TopDomains.TopDomains)
 
     val agentToCountBC = sc.broadcast(agentToCount)
-    val udfWordCreation = ProxyWordCreation.udfWordCreation(topDomains, agentToCountBC, timeCuts, entropyCuts, agentCuts)
+    val udfWordCreation = ProxyWordCreation.udfWordCreation(topDomains, agentToCountBC, entropyCuts)
 
     val ipWord = dataFrame.withColumn(Word,
       udfWordCreation(dataFrame(Host),

--- a/spot-ml/src/main/scala/org/apache/spot/proxy/ProxySuspiciousConnectsModel.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/proxy/ProxySuspiciousConnectsModel.scala
@@ -123,7 +123,7 @@ object ProxySuspiciousConnectsModel {
     val EntropyCuts = Array(0.0, 0.3, 0.6, 0.9, 1.2,
       1.5, 1.8, 2.1, 2.4, 2.7,
       3.0, 3.3, 3.6, 3.9, 4.2,
-      4.5, 4.8, 5.1, 5.4, 1.0 / 0)
+      4.5, 4.8, 5.1, 5.4, Double.PositiveInfinity)
 
     val agentToCount: Map[String, Long] =
       selectedRecords.select(UserAgent)

--- a/spot-ml/src/main/scala/org/apache/spot/proxy/ProxyWordCreation.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/proxy/ProxyWordCreation.scala
@@ -63,9 +63,9 @@ object ProxyWordCreation {
         // Just the top level content type for now
         if (contentType.split('/').length > 0) contentType.split('/')(0) else "unknown_content_type",
         // Exponential cutoffs base 2
-        ExponentialCutoffs.logBaseXInt(agentCounts.value(userAgent), 2),
+        MathUtils.logBaseXInt(agentCounts.value(userAgent), 2),
         // Exponential cutoffs base 2
-        ExponentialCutoffs.logBaseXInt(uri.length(), 2),
+        MathUtils.logBaseXInt(uri.length(), 2),
         // Response code using all 3 digits
         if (responseCode != null) responseCode else "unknown_response_code").mkString("_")
     } match {

--- a/spot-ml/src/main/scala/org/apache/spot/proxy/ProxyWordCreation.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/proxy/ProxyWordCreation.scala
@@ -29,7 +29,7 @@ object ProxyWordCreation {
 
   def udfWordCreation(topDomains : Broadcast[Set[String]],
                       agentCounts : Broadcast[Map[String, Long]],
-                      entropyCuts: Array[Double]) =
+                      EntropyCuts: Array[Double]) =
     udf((host: String, time: String, reqMethod: String, uri: String, contentType: String, userAgent: String, responseCode: String) =>
       ProxyWordCreation.proxyWord(host,
         time,
@@ -40,7 +40,7 @@ object ProxyWordCreation {
         responseCode,
         topDomains,
         agentCounts,
-        entropyCuts))
+        EntropyCuts))
 
 
   def proxyWord(proxyHost: String,
@@ -52,14 +52,14 @@ object ProxyWordCreation {
                 responseCode: String,
                 topDomains: Broadcast[Set[String]],
                 agentCounts: Broadcast[Map[String, Long]],
-                entropyCuts: Array[Double]): String = {
+                EntropyCuts: Array[Double]): String = {
     Try{
       List(topDomain(proxyHost, topDomains.value).toString,
         // Time binned by hours
         TimeUtilities.getTimeAsHour(time).toString,
         reqMethod,
-        // Fixed and equally spaced cutoffs
-        Quantiles.bin(Entropy.stringEntropy(uri), entropyCuts),
+        // Fixed cutoffs
+        Quantiles.bin(Entropy.stringEntropy(uri), EntropyCuts),
         // Just the top level content type for now
         if (contentType.split('/').length > 0) contentType.split('/')(0) else "unknown_content_type",
         // Exponential cutoffs base 2

--- a/spot-ml/src/main/scala/org/apache/spot/proxy/ProxyWordCreation.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/proxy/ProxyWordCreation.scala
@@ -19,6 +19,7 @@ package org.apache.spot.proxy
 
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.functions._
+import org.apache.spot.proxy.ProxySuspiciousConnectsModel.EntropyCuts
 import org.apache.spot.utilities._
 import org.apache.spot.utilities.data.validation.InvalidDataHandler
 
@@ -28,8 +29,7 @@ import scala.util.{Success, Try}
 object ProxyWordCreation {
 
   def udfWordCreation(topDomains : Broadcast[Set[String]],
-                      agentCounts : Broadcast[Map[String, Long]],
-                      EntropyCuts: Array[Double]) =
+                      agentCounts: Broadcast[Map[String, Long]]) =
     udf((host: String, time: String, reqMethod: String, uri: String, contentType: String, userAgent: String, responseCode: String) =>
       ProxyWordCreation.proxyWord(host,
         time,
@@ -39,8 +39,7 @@ object ProxyWordCreation {
         userAgent,
         responseCode,
         topDomains,
-        agentCounts,
-        EntropyCuts))
+        agentCounts))
 
 
   def proxyWord(proxyHost: String,
@@ -51,8 +50,7 @@ object ProxyWordCreation {
                 userAgent: String,
                 responseCode: String,
                 topDomains: Broadcast[Set[String]],
-                agentCounts: Broadcast[Map[String, Long]],
-                EntropyCuts: Array[Double]): String = {
+                agentCounts: Broadcast[Map[String, Long]]): String = {
     Try{
       List(topDomain(proxyHost, topDomains.value).toString,
         // Time binned by hours

--- a/spot-ml/src/main/scala/org/apache/spot/utilities/ExponentialCutoffs.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/utilities/ExponentialCutoffs.scala
@@ -17,36 +17,17 @@
 
 package org.apache.spot.utilities
 
+import scala.math.log10
 
-object TimeUtilities {
 
-
+object ExponentialCutoffs {
   /**
-    * It converts HH:MM:SS string to seconds
+    * Answers the question "To what power must "base" be raised, in order to yield "x"?  https://en.wikipedia.org/wiki/Logarithm
     *
-    * @param timeStr This is time in the form of a string
-    * @return It returns time converted to seconds
+    * @param x    This is a Double which is the result of the formula: base to the power of y = x
+    * @param base This is the base of the number we are trying to find
+    * @return A rounded down integer of y
     */
-
-  def getTimeAsDouble(timeStr: String) : Double = {
-    val s = timeStr.split(":")
-    val hours = s(0).toInt
-    val minutes = s(1).toInt
-    val seconds = s(2).toInt
-
-    (3600*hours + 60*minutes + seconds).toDouble
-  }
-
-  /**
-    * It takes only the hour element of time
-    *
-    * @param timeStr This is time in the form of a string
-    * @return It returns only the hour of time
-    */
-  def getTimeAsHour(timeStr: String): Int = {
-    val s = timeStr.split(":")
-    val hours = s(0).toInt
-    hours
-  }
+  def logBaseXInt(x: Double, base: Int): Int = if (x == 0) 0 else (log10(x) / log10(base)).toInt
 
 }

--- a/spot-ml/src/main/scala/org/apache/spot/utilities/MathUtils.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/utilities/MathUtils.scala
@@ -15,30 +15,17 @@
  * limitations under the License.
  */
 
-
 package org.apache.spot.utilities
 
-import org.apache.spot.testutils.TestingSparkContextFlatSpec
-import org.scalatest.Matchers
+import scala.math.log10
 
-/**
-  * Created by galujanm on 5/17/17.
-  */
-class ExponentialCutoffsTest extends TestingSparkContextFlatSpec with Matchers {
-
-  "logBaseXInt" should "return the power in which the base is raised, in order to yield x rounded down to the nearest integer" in {
-
-    val power1 = ExponentialCutoffs.logBaseXInt(4.0, 2)
-    val power2 = ExponentialCutoffs.logBaseXInt(8.0, 2)
-    val power3 = ExponentialCutoffs.logBaseXInt(1.9, 2)
-    val power4 = ExponentialCutoffs.logBaseXInt(9.5, 3)
-
-    power1 shouldBe 2
-    power2 shouldBe 3
-    power3 shouldBe 0
-    power4 shouldBe 2
-
-
-  }
-
+object MathUtils {
+  /**
+    * Answers the question "To what power must "base" be raised, in order to yield "x"?  https://en.wikipedia.org/wiki/Logarithm
+    *
+    * @param x    This is a Double which is the result of the formula: base to the power of y = x
+    * @param base This is the base of the number we are trying to find
+    * @return y rounded down to an integer
+    */
+  def logBaseXInt(x: Double, base: Int): Int = if (x == 0) 0 else (log10(x) / log10(base)).toInt
 }

--- a/spot-ml/src/test/scala/org/apache/spot/QuantilesTest.scala
+++ b/spot-ml/src/test/scala/org/apache/spot/QuantilesTest.scala
@@ -18,9 +18,9 @@
 package org.apache.spot
 
 import org.apache.spark.rdd.RDD
+import org.apache.spot.testutils.TestingSparkContextFlatSpec
 import org.apache.spot.utilities.Quantiles
 import org.scalatest.Matchers
-import testutils.TestingSparkContextFlatSpec
 
 
 class QuantilesTest extends TestingSparkContextFlatSpec with Matchers {

--- a/spot-ml/src/test/scala/org/apache/spot/proxy/ProxyWordCreationTest.scala
+++ b/spot-ml/src/test/scala/org/apache/spot/proxy/ProxyWordCreationTest.scala
@@ -1,0 +1,287 @@
+package org.apache.spot.proxy
+
+
+import org.apache.log4j.{Level, LogManager}
+import org.apache.spot.SuspiciousConnectsArgumentParser.SuspiciousConnectsConfig
+import org.apache.spot.proxy.ProxySchema.Word
+import org.apache.spot.testutils.TestingSparkContextFlatSpec
+import org.scalatest.Matchers
+
+
+class ProxyWordCreationTest extends TestingSparkContextFlatSpec with Matchers {
+
+  val testConfigProxy = SuspiciousConnectsConfig(analysis = "proxy",
+    inputPath = "",
+    feedbackFile = "",
+    duplicationFactor = 1,
+    topicCount = 20,
+    hdfsScoredConnect = "",
+    threshold = 1.0d,
+    maxResults = 1000,
+    outputDelimiter = "\t",
+    ldaPRGSeed = None,
+    ldaMaxiterations = 20,
+    ldaAlpha = 1.02,
+    ldaBeta = 1.001)
+
+  "proxy word creation" should "return the correct word given the rules to form the word" in {
+
+    val logger = LogManager.getLogger("ProxyWordCreation")
+    logger.setLevel(Level.WARN)
+
+    // case class ProxyInput has the form:
+    // 1  p_date:String,
+    // 2  p_time:String,      <- currently used for feature creation
+    // 3  clientip:String,
+    // 4  host:String,        <- currently used for feature creation
+    // 5  reqmethod:String,   <- currently used for feature creation
+    // 6  useragent:String,   <- currently used for feature creation
+    // 7  resconttype:String, <- currently used for feature creation
+    // 8  duration:Int,
+    // 9  username:String,
+    // 10 webcat:String,
+    // 11 referer:String,
+    // 12 respcode:String,    <- currently used for feature creation
+    // 13 uriport:Int,
+    // 14 uripath:String,
+    // 15 uriquery:String,
+    // 16 serverip:String,
+    // 17 scbytes:Int,
+    // 18 csbytes:Int,
+    // 19 fulluri:String)     <- currently used for feature creation
+
+    val record1 = ProxyInput(
+      "2016-10-03",
+      "00:57:36",
+      "127.0.0.1",
+      "intel.com",
+      "PUT",
+      "Mozilla/5.0",
+      "text/plain",
+      230,
+      "-",
+      "Technology/Internet",
+      "http://www.spoonflower.com/tags/color",
+      "202",
+      80,
+      "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
+      "-",
+      "127.0.0.1",
+      338,
+      647,
+      "ab") //entropy = 1.0
+
+    val record2 = ProxyInput(
+      "2016-10-03",
+      "01:57:36",
+      "127.0.0.1",
+      "maw.bronto.com",
+      "PUT",
+      "Safari/537.36",
+      "image",
+      230,
+      "-",
+      "Technology/Internet",
+      "http://www.spoonflower.com/tags/color",
+      "202",
+      80,
+      "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
+      "-",
+      "127.0.0.1",
+      338,
+      647,
+      "abc") //entropy = 1.5849625007211559
+
+    val record3 = ProxyInput(
+      "2016-10-03",
+      "02:57:36",
+      "127.0.0.1",
+      "maw.bronto.com",
+      "PUT",
+      "Safari/537.36",
+      "image",
+      230,
+      "-",
+      "Technology/Internet",
+      "http://www.spoonflower.com/tags/color",
+      "304",
+      80,
+      "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
+      "-",
+      "127.0.0.1",
+      338,
+      647,
+      "abcd") //entropy = 2.0
+
+    val record4 = ProxyInput(
+      "2016-10-03",
+      "03:57:36",
+      "127.0.0.1",
+      "maw.bronto.com",
+      "PUT",
+      "Safari/537.36",
+      "binary",
+      230,
+      "-",
+      "Technology/Internet",
+      "http://www.spoonflower.com/tags/color",
+      "304",
+      80,
+      "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
+      "-",
+      "127.0.0.1",
+      338,
+      647,
+      "abcde") // entropy = 2.321928094887362
+
+    val record5 = ProxyInput(
+      "2016-10-03",
+      "10:57:36",
+      "127.0.0.1",
+      "maw.bronto.com",
+      "PUT",
+      "Safari/537.36",
+      "binary",
+      230,
+      "-",
+      "Technology/Internet",
+      "http://www.spoonflower.com/tags/color",
+      "206",
+      80,
+      "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
+      "-",
+      "127.0.0.1",
+      338,
+      647,
+      "abcdef") //entropy = 2.584962500721155
+
+    val record6 = ProxyInput(
+      "2016-10-03",
+      "11:57:36",
+      "127.0.0.1",
+      "maw.bronto.com",
+      "GET",
+      "Safari/537.36",
+      "binary",
+      230,
+      "-",
+      "Technology/Internet",
+      "http://www.spoonflower.com/tags/color",
+      "206",
+      80,
+      "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
+      "-",
+      "127.0.0.1",
+      338,
+      647,
+      "abcdefghijklmnopqrstuvwxyz") //4.70043971814109
+
+    val record7 = ProxyInput(
+      "2016-10-03",
+      "13:57:36",
+      "127.0.0.1",
+      "maw.bronto.com",
+      "GET",
+      "Safari/537.36",
+      "text/plain",
+      230,
+      "-",
+      "Technology/Internet",
+      "http://www.spoonflower.com/tags/color",
+      "200",
+      80,
+      "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
+      "-",
+      "127.0.0.1",
+      338,
+      647,
+      "aaa") //entropy = 0.0
+
+    val record8 = ProxyInput(
+      "2016-10-03",
+      "14:57:36",
+      "127.0.0.1",
+      "maw.bronto.com",
+      "GET",
+      "Safari/537.36",
+      "text/plain",
+      230,
+      "-",
+      "Technology/Internet",
+      "http://www.spoonflower.com/tags/color",
+      "200",
+      80,
+      "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
+      "-",
+      "127.0.0.1",
+      338,
+      647,
+      "aaabbb") //entropy 1.0
+
+    val record9 = ProxyInput(
+      "2016-10-03",
+      "22:57:36",
+      "127.0.0.1",
+      "maw.bronto.com",
+      "GET",
+      "Safari/537.36",
+      "text/plain",
+      230,
+      "-",
+      "Technology/Internet",
+      "http://www.spoonflower.com/tags/color",
+      "302",
+      80,
+      "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
+      "-",
+      "127.0.0.1",
+      338,
+      647,
+      "aaaaaaaaaaabbbbbbbbbbbccccccccccc") //entropy = 1.5849625007211559
+
+    val record10 = ProxyInput(
+      "2016-10-03",
+      "23:57:36",
+      "127.0.0.1",
+      "maw.bronto.com",
+      "GET",
+      "Safari/537.36",
+      "text/plain",
+      230,
+      "-",
+      "Technology/Internet",
+      "http://www.spoonflower.com/tags/color",
+      "302",
+      80,
+      "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
+      "-",
+      "127.0.0.1",
+      338,
+      647,
+      "maw.bronto.com/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd" +
+        "-4e804fd354ef/fiddle") // entropy = 4.832854333602748
+
+
+    val data = sqlContext.createDataFrame(Seq(record1, record2, record3, record4, record5, record6, record7, record8,
+      record9, record10))
+
+    val scoredData = ProxySuspiciousConnectsAnalysis.detectProxyAnomalies(data, testConfigProxy,
+      sparkContext,
+      sqlContext,
+      logger)
+
+    val words = scoredData.collect().map(_.getAs[String](Word))
+
+    words(0) shouldBe "2_0_PUT_4_text_0_1_202"
+    words(1) shouldBe "1_1_PUT_6_image_3_1_202"
+    words(2) shouldBe "1_2_PUT_7_image_3_2_304"
+    words(3) shouldBe "1_3_PUT_8_binary_3_2_304"
+    words(4) shouldBe "1_10_PUT_9_binary_3_2_206"
+    words(5) shouldBe "1_11_GET_16_binary_3_4_206"
+    words(6) shouldBe "1_13_GET_0_text_3_1_200"
+    words(7) shouldBe "1_14_GET_4_text_3_2_200"
+    words(8) shouldBe "1_22_GET_6_text_3_5_302"
+    words(9) shouldBe "1_23_GET_17_text_3_6_302"
+
+  }
+}

--- a/spot-ml/src/test/scala/org/apache/spot/proxy/ProxyWordCreationTest.scala
+++ b/spot-ml/src/test/scala/org/apache/spot/proxy/ProxyWordCreationTest.scala
@@ -1,12 +1,27 @@
-package org.apache.spot.proxy
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+package org.apache.spot.proxy
 
 import org.apache.log4j.{Level, LogManager}
 import org.apache.spot.SuspiciousConnectsArgumentParser.SuspiciousConnectsConfig
 import org.apache.spot.proxy.ProxySchema.Word
 import org.apache.spot.testutils.TestingSparkContextFlatSpec
 import org.scalatest.Matchers
-
 
 class ProxyWordCreationTest extends TestingSparkContextFlatSpec with Matchers {
 
@@ -24,7 +39,7 @@ class ProxyWordCreationTest extends TestingSparkContextFlatSpec with Matchers {
     ldaAlpha = 1.02,
     ldaBeta = 1.001)
 
-  "proxy word creation" should "return the correct word given the rules to form the word" in {
+  "proxy word creation" should "return the correct word given the set of rules to form the word" in {
 
     val logger = LogManager.getLogger("ProxyWordCreation")
     logger.setLevel(Level.WARN)
@@ -50,220 +65,67 @@ class ProxyWordCreationTest extends TestingSparkContextFlatSpec with Matchers {
     // 18 csbytes:Int,
     // 19 fulluri:String)     <- currently used for feature creation
 
-    val record1 = ProxyInput(
-      "2016-10-03",
-      "00:57:36",
-      "127.0.0.1",
-      "intel.com",
-      "PUT",
-      "Mozilla/5.0",
-      "text/plain",
-      230,
-      "-",
-      "Technology/Internet",
-      "http://www.spoonflower.com/tags/color",
-      "202",
-      80,
+    val noAlexaPutLoEntroTextRareAgentShortUri202 = ProxyInput("2016-10-03", "00:57:36", "127.0.0.1", "intel.com", "PUT",
+      "Mozilla/5.0", "text/plain", 230, "-", "Technology/Internet", "http://www.spoonflower.com/tags/color", "202", 80,
       "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
-      "-",
-      "127.0.0.1",
-      338,
-      647,
-      "ab") //entropy = 1.0
+      "-", "127.0.0.1", 338, 647, "ab")
 
-    val record2 = ProxyInput(
-      "2016-10-03",
-      "01:57:36",
-      "127.0.0.1",
-      "maw.bronto.com",
-      "PUT",
-      "Safari/537.36",
-      "image",
-      230,
-      "-",
-      "Technology/Internet",
-      "http://www.spoonflower.com/tags/color",
-      "202",
-      80,
+    val AlexaPutMidEntroImagePopularAgentShortUri202 = ProxyInput("2016-10-03", "01:57:36", "127.0.0.1", "maw.bronto.com",
+      "PUT", "Safari/537.36", "image", 230, "-", "Technology/Internet", "http://www.spoonflower.com/tags/color", "202", 80,
       "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
-      "-",
-      "127.0.0.1",
-      338,
-      647,
-      "abc") //entropy = 1.5849625007211559
+      "-", "127.0.0.1", 338, 647, "abc")
 
-    val record3 = ProxyInput(
-      "2016-10-03",
-      "02:57:36",
-      "127.0.0.1",
-      "maw.bronto.com",
-      "PUT",
-      "Safari/537.36",
-      "image",
-      230,
-      "-",
-      "Technology/Internet",
-      "http://www.spoonflower.com/tags/color",
-      "304",
-      80,
+    val AlexaPutMidEntroImagePopularAgentShortUri304 = ProxyInput("2016-10-03", "02:57:36", "127.0.0.1", "maw.bronto.com",
+      "PUT", "Safari/537.36", "image", 230, "-", "Technology/Internet", "http://www.spoonflower.com/tags/color", "304", 80,
       "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
-      "-",
-      "127.0.0.1",
-      338,
-      647,
-      "abcd") //entropy = 2.0
+      "-", "127.0.0.1", 338, 647, "abcd")
 
-    val record4 = ProxyInput(
-      "2016-10-03",
-      "03:57:36",
-      "127.0.0.1",
-      "maw.bronto.com",
-      "PUT",
-      "Safari/537.36",
-      "binary",
-      230,
-      "-",
-      "Technology/Internet",
-      "http://www.spoonflower.com/tags/color",
-      "304",
-      80,
+    val AlexaPutMidEntroBinaryPopularAgentShortUri304 = ProxyInput("2016-10-03", "03:57:36", "127.0.0.1", "maw.bronto.com",
+      "PUT", "Safari/537.36", "binary", 230, "-", "Technology/Internet", "http://www.spoonflower.com/tags/color", "304", 80,
       "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
-      "-",
-      "127.0.0.1",
-      338,
-      647,
-      "abcde") // entropy = 2.321928094887362
+      "-", "127.0.0.1", 338, 647, "abcde")
 
-    val record5 = ProxyInput(
-      "2016-10-03",
-      "10:57:36",
-      "127.0.0.1",
-      "maw.bronto.com",
-      "PUT",
-      "Safari/537.36",
-      "binary",
-      230,
-      "-",
-      "Technology/Internet",
-      "http://www.spoonflower.com/tags/color",
-      "206",
-      80,
+    val AlexaPutMidEntroBinaryPopularAgentShortUri206 = ProxyInput("2016-10-03", "10:57:36", "127.0.0.1", "maw.bronto.com",
+      "PUT", "Safari/537.36", "binary", 230, "-", "Technology/Internet", "http://www.spoonflower.com/tags/color", "206", 80,
       "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
-      "-",
-      "127.0.0.1",
-      338,
-      647,
-      "abcdef") //entropy = 2.584962500721155
+      "-", "127.0.0.1", 338, 647, "abcdef")
 
-    val record6 = ProxyInput(
-      "2016-10-03",
-      "11:57:36",
-      "127.0.0.1",
-      "maw.bronto.com",
-      "GET",
-      "Safari/537.36",
-      "binary",
-      230,
-      "-",
-      "Technology/Internet",
-      "http://www.spoonflower.com/tags/color",
-      "206",
-      80,
+    val AlexaGetHiEntroBinaryPopularAgentShortUri206 = ProxyInput("2016-10-03", "11:57:36", "127.0.0.1", "maw.bronto.com",
+      "GET", "Safari/537.36", "binary", 230, "-", "Technology/Internet", "http://www.spoonflower.com/tags/color", "206", 80,
       "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
-      "-",
-      "127.0.0.1",
-      338,
-      647,
-      "abcdefghijklmnopqrstuvwxyz") //4.70043971814109
+      "-", "127.0.0.1", 338, 647, "abcdefghijklmnopqrstuvwxyz")
 
-    val record7 = ProxyInput(
-      "2016-10-03",
-      "13:57:36",
-      "127.0.0.1",
-      "maw.bronto.com",
-      "GET",
-      "Safari/537.36",
-      "text/plain",
-      230,
-      "-",
-      "Technology/Internet",
-      "http://www.spoonflower.com/tags/color",
-      "200",
-      80,
+    val AlexaGetZeroEntroTextPopularAgentShortUri200 = ProxyInput("2016-10-03", "13:57:36", "127.0.0.1", "maw.bronto.com",
+      "GET", "Safari/537.36", "text/plain", 230, "-", "Technology/Internet", "http://www.spoonflower.com/tags/color", "200", 80,
       "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
-      "-",
-      "127.0.0.1",
-      338,
-      647,
-      "aaa") //entropy = 0.0
+      "-", "127.0.0.1", 338, 647, "aaa")
 
-    val record8 = ProxyInput(
-      "2016-10-03",
-      "14:57:36",
-      "127.0.0.1",
-      "maw.bronto.com",
-      "GET",
-      "Safari/537.36",
-      "text/plain",
-      230,
-      "-",
-      "Technology/Internet",
-      "http://www.spoonflower.com/tags/color",
-      "200",
-      80,
+    val AlexaGetLoEntroTextPopularAgentShortUri200 = ProxyInput("2016-10-03", "14:57:36", "127.0.0.1", "maw.bronto.com",
+      "GET", "Safari/537.36", "text/plain", 230, "-", "Technology/Internet", "http://www.spoonflower.com/tags/color", "200", 80,
       "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
-      "-",
-      "127.0.0.1",
-      338,
-      647,
-      "aaabbb") //entropy 1.0
+      "-", "127.0.0.1", 338, 647, "aaabbb")
 
-    val record9 = ProxyInput(
-      "2016-10-03",
-      "22:57:36",
-      "127.0.0.1",
-      "maw.bronto.com",
-      "GET",
-      "Safari/537.36",
-      "text/plain",
-      230,
-      "-",
-      "Technology/Internet",
-      "http://www.spoonflower.com/tags/color",
-      "302",
-      80,
+    val AlexaGetMidEntroTextPopularAgentMidUri302 = ProxyInput("2016-10-03", "22:57:36", "127.0.0.1", "maw.bronto.com",
+      "GET", "Safari/537.36", "text/plain", 230, "-", "Technology/Internet", "http://www.spoonflower.com/tags/color", "302", 80,
       "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
-      "-",
-      "127.0.0.1",
-      338,
-      647,
-      "aaaaaaaaaaabbbbbbbbbbbccccccccccc") //entropy = 1.5849625007211559
+      "-", "127.0.0.1", 338, 647, "aaaaaaaaaaabbbbbbbbbbbccccccccccc")
 
-    val record10 = ProxyInput(
-      "2016-10-03",
-      "23:57:36",
-      "127.0.0.1",
-      "maw.bronto.com",
-      "GET",
-      "Safari/537.36",
-      "text/plain",
-      230,
-      "-",
-      "Technology/Internet",
-      "http://www.spoonflower.com/tags/color",
-      "302",
-      80,
-      "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
-      "-",
-      "127.0.0.1",
-      338,
-      647,
-      "maw.bronto.com/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd" +
-        "-4e804fd354ef/fiddle") // entropy = 4.832854333602748
+    val AlexaGetHiEntroTextPopularAgentLargeUri302 = ProxyInput("2016-10-03", "23:57:36", "127.0.0.1", "maw.bronto.com",
+      "GET", "Safari/537.36", "text/plain", 230, "-", "Technology/Internet", "http://www.spoonflower.com/tags/color", "302",
+      80, "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
+      "-", "127.0.0.1", 338, 647, "maw.bronto.com/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts" +
+        "/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle")
 
-
-    val data = sqlContext.createDataFrame(Seq(record1, record2, record3, record4, record5, record6, record7, record8,
-      record9, record10))
+    val data = sqlContext.createDataFrame(Seq(noAlexaPutLoEntroTextRareAgentShortUri202,
+      AlexaPutMidEntroImagePopularAgentShortUri202,
+      AlexaPutMidEntroImagePopularAgentShortUri304,
+      AlexaPutMidEntroBinaryPopularAgentShortUri304,
+      AlexaPutMidEntroBinaryPopularAgentShortUri206,
+      AlexaGetHiEntroBinaryPopularAgentShortUri206,
+      AlexaGetZeroEntroTextPopularAgentShortUri200,
+      AlexaGetLoEntroTextPopularAgentShortUri200,
+      AlexaGetMidEntroTextPopularAgentMidUri302,
+      AlexaGetHiEntroTextPopularAgentLargeUri302))
 
     val scoredData = ProxySuspiciousConnectsAnalysis.detectProxyAnomalies(data, testConfigProxy,
       sparkContext,
@@ -282,6 +144,5 @@ class ProxyWordCreationTest extends TestingSparkContextFlatSpec with Matchers {
     words(7) shouldBe "1_14_GET_4_text_3_2_200"
     words(8) shouldBe "1_22_GET_6_text_3_5_302"
     words(9) shouldBe "1_23_GET_17_text_3_6_302"
-
   }
 }

--- a/spot-ml/src/test/scala/org/apache/spot/utilities/ExponentialCutoffsTest.scala
+++ b/spot-ml/src/test/scala/org/apache/spot/utilities/ExponentialCutoffsTest.scala
@@ -15,38 +15,30 @@
  * limitations under the License.
  */
 
+
 package org.apache.spot.utilities
 
+import org.apache.spot.testutils.TestingSparkContextFlatSpec
+import org.scalatest.Matchers
 
-object TimeUtilities {
+/**
+  * Created by galujanm on 5/17/17.
+  */
+class ExponentialCutoffsTest extends TestingSparkContextFlatSpec with Matchers {
+
+  "logBaseXInt" should "return the power in which the base is raised, in order to yield x rounded down to the nearest integer" in {
+
+    val power1 = ExponentialCutoffs.logBaseXInt(4.0, 2)
+    val power2 = ExponentialCutoffs.logBaseXInt(8.0, 2)
+    val power3 = ExponentialCutoffs.logBaseXInt(1.9, 2)
+    val power4 = ExponentialCutoffs.logBaseXInt(9.5, 3)
+
+    power1 shouldBe 2
+    power2 shouldBe 3
+    power3 shouldBe 0
+    power4 shouldBe 2
 
 
-  /**
-    * It converts HH:MM:SS string to seconds
-    *
-    * @param timeStr This is time in the form of a string
-    * @return It returns time converted to seconds
-    */
-
-  def getTimeAsDouble(timeStr: String) : Double = {
-    val s = timeStr.split(":")
-    val hours = s(0).toInt
-    val minutes = s(1).toInt
-    val seconds = s(2).toInt
-
-    (3600*hours + 60*minutes + seconds).toDouble
-  }
-
-  /**
-    * It takes only the hour element of time
-    *
-    * @param timeStr This is time in the form of a string
-    * @return It returns only the hour of time
-    */
-  def getTimeAsHour(timeStr: String): Int = {
-    val s = timeStr.split(":")
-    val hours = s(0).toInt
-    hours
   }
 
 }

--- a/spot-ml/src/test/scala/org/apache/spot/utilities/MathUtilsTest.scala
+++ b/spot-ml/src/test/scala/org/apache/spot/utilities/MathUtilsTest.scala
@@ -17,17 +17,24 @@
 
 package org.apache.spot.utilities
 
-import scala.math.log10
+import org.apache.spot.testutils.TestingSparkContextFlatSpec
+import org.scalatest.Matchers
 
 
-object ExponentialCutoffs {
-  /**
-    * Answers the question "To what power must "base" be raised, in order to yield "x"?  https://en.wikipedia.org/wiki/Logarithm
-    *
-    * @param x    This is a Double which is the result of the formula: base to the power of y = x
-    * @param base This is the base of the number we are trying to find
-    * @return A rounded down integer of y
-    */
-  def logBaseXInt(x: Double, base: Int): Int = if (x == 0) 0 else (log10(x) / log10(base)).toInt
+class MathUtilsTest extends TestingSparkContextFlatSpec with Matchers {
 
+  "logBaseXInt" should "return the power in which the base is raised, in order to yield x rounded down to the nearest integer" in {
+
+    val power1 = MathUtils.logBaseXInt(4.0, 2)
+    val power2 = MathUtils.logBaseXInt(8.0, 2)
+    val power3 = MathUtils.logBaseXInt(1.9, 2)
+    val power4 = MathUtils.logBaseXInt(9.5, 3)
+
+    power1 shouldBe 2
+    power2 shouldBe 3
+    power3 shouldBe 0
+    power4 shouldBe 2
+
+
+  }
 }

--- a/spot-ml/src/test/scala/org/apache/spot/utilities/TimeUtilitiesTest.scala
+++ b/spot-ml/src/test/scala/org/apache/spot/utilities/TimeUtilitiesTest.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spot.utilities
+
+import org.apache.spot.testutils.TestingSparkContextFlatSpec
+import org.scalatest.Matchers
+
+
+class TimeUtilitiesTest extends TestingSparkContextFlatSpec with Matchers {
+
+  val time1 = "2:35:45"
+  val time2 = "14:00:08"
+  val time3 = "1:35:56"
+  val time4 = "0:25:00"
+
+  "getTimeAsDouble" should "return the time converted to seconds given the format HH:MM:SS..." in {
+
+    val timeSec1 = TimeUtilities.getTimeAsDouble(time1)
+    val timeSec2 = TimeUtilities.getTimeAsDouble(time2)
+    val timeSec3 = TimeUtilities.getTimeAsDouble(time3)
+    val timeSec4 = TimeUtilities.getTimeAsDouble(time4)
+
+    timeSec1 shouldBe 9345.0
+    timeSec2 shouldBe 50408.0
+    timeSec3 shouldBe 5756.0
+    timeSec4 shouldBe 1500.0
+  }
+
+  "getTimeAsHour" should "return only the hour part of time given the format HH:MM:SS..." in {
+
+
+    val hour1 = TimeUtilities.getTimeAsHour(time1).toString
+    val hour2 = TimeUtilities.getTimeAsHour(time2).toString
+    val hour3 = TimeUtilities.getTimeAsHour(time3).toString
+    val hour4 = TimeUtilities.getTimeAsHour(time4).toString
+
+    hour1 shouldBe "2"
+    hour2 shouldBe "14"
+    hour3 shouldBe "1"
+    hour4 shouldBe "0"
+  }
+
+}


### PR DESCRIPTION
In this pull request we propose to move away from quantiles and we are also suggesting an additional feature. For more information about the problem statement and advantages of the changes please check the Jira issue: https://issues.apache.org/jira/browse/SPOT-153?jql=project%20%3D%20SPOT

Summary of changes: 

class ProxySuspiciousConnectsModel: We are moving away from quantiles which are computationally expensive and data dependent. In this new version we got rid of the val timeCuts which computed quantiles. We also modified val entropyCuts to have a fixed number of buckets and therefore quantiles are no longer computed. All references to timeCuts and agentCuts were removed.

object ProxyWordCreation: We got rid of the timeCuts and agentCuts references because they are no longer computed in quantiles. entropy cuts is still passed as a parameter but the buckets are fixed. A new feature was added to the word formation which considers the URI length in exponential cutoffs.

object ExponentialCutoffs: This object has a method which answers the question: To what power must base be raise in order to yield x. It offers the flexibility to change the base.

object Quantiles: No changes were made to this object.

object TimeUtilities: A mew method getTimeAsHour was added in order to extract only the hour element of the string time.

class ExponentialCutoffsTest: A unit test was added to test this function

class TimeUtilitiesTest: Unit tests were added to test the methods of TimeUtilities

class QuantilesTest: No changes were made to this test.