### PR TITLE
Spot-128 Make every pipeline to return results to main program

### DIFF
--- a/spot-ml/src/main/scala/org/apache/spot/dns/DNSSuspiciousConnectsAnalysis.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/dns/DNSSuspiciousConnectsAnalysis.scala
@@ -67,7 +67,7 @@ object DNSSuspiciousConnectsAnalysis {
     logger.info("Identifying outliers")
     val scoredDNSRecords = model.score(sparkContext, sqlContext, dnsRecords, config.userDomain)
 
-    val filteredScored = filterScoredRecords(scoredDNSRecords, config.threshold).orderBy(Score)
+    val filteredScored = filterScoredRecords(scoredDNSRecords, config.threshold)
 
     val orderedDNSRecords = filteredScored.orderBy(Score)
 

--- a/spot-ml/src/main/scala/org/apache/spot/dns/DNSSuspiciousConnectsAnalysis.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/dns/DNSSuspiciousConnectsAnalysis.scala
@@ -62,7 +62,7 @@ object DNSSuspiciousConnectsAnalysis {
 
     logger.info("Fitting probabilistic model to data")
     val model =
-      DNSSuspiciousConnectsModel.trainNewModel(sparkContext, sqlContext, logger, config, dnsRecords, config.topicCount)
+      DNSSuspiciousConnectsModel.trainModel(sparkContext, sqlContext, logger, config, dnsRecords)
 
     logger.info("Identifying outliers")
     val scoredDNSRecords = model.score(sparkContext, sqlContext, dnsRecords, config.userDomain)

--- a/spot-ml/src/main/scala/org/apache/spot/dns/model/DNSSuspiciousConnectsModel.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/dns/model/DNSSuspiciousConnectsModel.scala
@@ -158,15 +158,13 @@ object DNSSuspiciousConnectsModel {
     * @param config       Analysis configuration object containing CLI parameters.
     *                     Contains the path to the feedback file in config.scoresFile
     * @param inputRecords Data used to train the model.
-    * @param topicCount   Number of topics (traffic profiles) used to build the model.
     * @return A new [[DNSSuspiciousConnectsModel]] instance trained on the dataframe and feedback file.
     */
-  def trainNewModel(sparkContext: SparkContext,
-                    sqlContext: SQLContext,
-                    logger: Logger,
-                    config: SuspiciousConnectsConfig,
-                    inputRecords: DataFrame,
-                    topicCount: Int): DNSSuspiciousConnectsModel = {
+  def trainModel(sparkContext: SparkContext,
+                 sqlContext: SQLContext,
+                 logger: Logger,
+                 config: SuspiciousConnectsConfig,
+                 inputRecords: DataFrame): DNSSuspiciousConnectsModel = {
 
     logger.info("Training DNS suspicious connects model from " + config.inputPath)
 
@@ -297,7 +295,7 @@ object DNSSuspiciousConnectsModel {
       .toMap
 
 
-    new DNSSuspiciousConnectsModel(topicCount,
+    new DNSSuspiciousConnectsModel(config.topicCount,
       ipToTopicMix,
       wordToPerTopicProb,
       timeCuts,

--- a/spot-ml/src/main/scala/org/apache/spot/netflow/FlowSuspiciousConnectsAnalysis.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/netflow/FlowSuspiciousConnectsAnalysis.scala
@@ -46,7 +46,7 @@ object FlowSuspiciousConnectsAnalysis {
 
     logger.info("Fitting probabilistic model to data")
     val model =
-      FlowSuspiciousConnectsModel.trainNewModel(sparkContext, sqlContext, logger, config, flowRecords, config.topicCount)
+      FlowSuspiciousConnectsModel.trainModel(sparkContext, sqlContext, logger, config, flowRecords)
 
     logger.info("Identifying outliers")
     val scoredFlowRecords = model.score(sparkContext, sqlContext, flowRecords)

--- a/spot-ml/src/main/scala/org/apache/spot/netflow/model/FlowSuspiciousConnectsModel.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/netflow/model/FlowSuspiciousConnectsModel.scala
@@ -157,16 +157,6 @@ object FlowSuspiciousConnectsModel {
     val dataWithWords = totalRecords.withColumn(SourceWord, FlowWordCreator.srcWordUDF(ModelColumns: _*))
       .withColumn(DestinationWord, FlowWordCreator.dstWordUDF(ModelColumns: _*))
 
-    dataWithWords.cache()
-    dataWithWords.count
-
-    // Save corrupt records, those records that failed to create the words
-    val corruptRecords = dataWithWords
-      .filter(dataWithWords(SourceWord) === InvalidDataHandler.WordError ||
-        dataWithWords(DestinationWord) === InvalidDataHandler.WordError)
-
-    InvalidDataHandler.showAndSaveCorruptRecords(corruptRecords, config.hdfsScoredConnect, logger)
-
     // Aggregate per-word counts at each IP
     val srcWordCounts = dataWithWords
       .filter(dataWithWords(SourceWord).notEqual(InvalidDataHandler.WordError))

--- a/spot-ml/src/main/scala/org/apache/spot/proxy/ProxySuspiciousConnectsAnalysis.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/proxy/ProxySuspiciousConnectsAnalysis.scala
@@ -22,6 +22,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SQLContext}
+import org.apache.spot.SuspiciousConnects.SuspiciousConnectsAnalysisResults
 import org.apache.spot.SuspiciousConnectsArgumentParser.SuspiciousConnectsConfig
 import org.apache.spot.proxy.ProxySchema._
 import org.apache.spot.utilities.data.validation.{InvalidDataHandler => dataValidation}
@@ -40,58 +41,37 @@ object ProxySuspiciousConnectsAnalysis {
     * @param logger       Logs execution progress, information and errors for user.
     */
   def run(config: SuspiciousConnectsConfig, sparkContext: SparkContext, sqlContext: SQLContext, logger: Logger,
-          inputProxyRecords: DataFrame) = {
+          inputProxyRecords: DataFrame): SuspiciousConnectsAnalysisResults = {
 
     logger.info("Starting proxy suspicious connects analysis.")
 
-    val cleanProxyRecords = filterAndSelectCleanProxyRecords(inputProxyRecords)
+    val proxyRecords = filterRecords(inputProxyRecords)
+      .select(InSchema: _*)
+      .na.fill(DefaultUserAgent, Seq(UserAgent))
+      .na.fill(DefaultResponseContentType, Seq(ResponseContentType))
 
-    val scoredProxyRecords = detectProxyAnomalies(cleanProxyRecords, config, sparkContext, sqlContext, logger)
+    logger.info("Fitting probabilistic model to data")
+    val model = ProxySuspiciousConnectsModel.trainNewModel(sparkContext, sqlContext, logger, config, proxyRecords)
 
+    logger.info("Identifying outliers")
+    val scoredProxyRecords = model.score(sparkContext, proxyRecords)
 
     // take the maxResults least probable events of probability below the threshold and sort
 
-    val filteredProxyRecords = filterScoredProxyRecords(scoredProxyRecords, config.threshold)
+    val filteredScored = filterScoredRecords(scoredProxyRecords, config.threshold)
 
-    val orderedProxyRecords = filteredProxyRecords.orderBy(Score)
+    val orderedProxyRecords = filteredScored.orderBy(Score)
 
-    val mostSuspiciousProxyRecords = if (config.maxResults > 0) orderedProxyRecords.limit(config.maxResults) else orderedProxyRecords
+    val mostSuspiciousProxyRecords =
+      if (config.maxResults > 0) orderedProxyRecords.limit(config.maxResults)
+      else orderedProxyRecords
 
     val outputProxyRecords = mostSuspiciousProxyRecords.select(OutSchema: _*)
 
-    logger.info("Proxy suspicious connects analysis completed")
-    logger.info("Saving results to: " + config.hdfsScoredConnect)
-    outputProxyRecords.map(_.mkString(config.outputDelimiter)).saveAsTextFile(config.hdfsScoredConnect)
+    val invalidProxyRecords = filterInvalidRecords(inputProxyRecords).select(InSchema: _*)
 
-    val invalidProxyRecords = filterAndSelectInvalidProxyRecords(inputProxyRecords)
-    dataValidation.showAndSaveInvalidRecords(invalidProxyRecords, config.hdfsScoredConnect, logger)
+    SuspiciousConnectsAnalysisResults(outputProxyRecords, invalidProxyRecords)
 
-    val corruptProxyRecords = filterAndSelectCorruptProxyRecords(scoredProxyRecords)
-    dataValidation.showAndSaveCorruptRecords(corruptProxyRecords, config.hdfsScoredConnect, logger)
-  }
-
-  /**
-    * Identify anomalous proxy log entries in in the provided data frame.
-    *
-    * @param data Data frame of proxy entries
-    * @param config
-    * @param sparkContext
-    * @param sqlContext
-    * @param logger
-    * @return
-    */
-  def detectProxyAnomalies(data: DataFrame,
-                           config: SuspiciousConnectsConfig,
-                           sparkContext: SparkContext,
-                           sqlContext: SQLContext,
-                           logger: Logger): DataFrame = {
-
-
-    logger.info("Fitting probabilistic model to data")
-    val model = ProxySuspiciousConnectsModel.trainNewModel(sparkContext, sqlContext, logger, config, data)
-    logger.info("Identifying outliers")
-
-    model.score(sparkContext, data)
   }
 
   /**
@@ -99,7 +79,7 @@ object ProxySuspiciousConnectsAnalysis {
     * @param inputProxyRecords raw proxy records.
     * @return
     */
-  def filterAndSelectCleanProxyRecords(inputProxyRecords: DataFrame): DataFrame = {
+  def filterRecords(inputProxyRecords: DataFrame): DataFrame = {
 
     val cleanProxyRecordsFilter = inputProxyRecords(Date).isNotNull &&
       inputProxyRecords(Time).isNotNull &&
@@ -109,9 +89,6 @@ object ProxySuspiciousConnectsAnalysis {
 
     inputProxyRecords
       .filter(cleanProxyRecordsFilter)
-      .select(InSchema: _*)
-      .na.fill(DefaultUserAgent, Seq(UserAgent))
-      .na.fill(DefaultResponseContentType, Seq(ResponseContentType))
   }
 
   /**
@@ -119,7 +96,7 @@ object ProxySuspiciousConnectsAnalysis {
     * @param inputProxyRecords raw proxy records.
     * @return
     */
-  def filterAndSelectInvalidProxyRecords(inputProxyRecords: DataFrame): DataFrame = {
+  def filterInvalidRecords(inputProxyRecords: DataFrame): DataFrame = {
 
     val invalidProxyRecordsFilter = inputProxyRecords(Date).isNull ||
       inputProxyRecords(Time).isNull ||
@@ -129,7 +106,6 @@ object ProxySuspiciousConnectsAnalysis {
 
     inputProxyRecords
       .filter(invalidProxyRecordsFilter)
-      .select(InSchema: _*)
   }
 
   /**
@@ -138,26 +114,12 @@ object ProxySuspiciousConnectsAnalysis {
     * @param threshold          score tolerance.
     * @return
     */
-  def filterScoredProxyRecords(scoredProxyRecords: DataFrame, threshold: Double): DataFrame = {
+  def filterScoredRecords(scoredProxyRecords: DataFrame, threshold: Double): DataFrame = {
 
     val filteredProxyRecordsFilter = scoredProxyRecords(Score).leq(threshold) &&
       scoredProxyRecords(Score).gt(dataValidation.ScoreError)
 
     scoredProxyRecords.filter(filteredProxyRecordsFilter)
-  }
-
-  /**
-    *
-    * @param scoredProxyRecords scored proxy records.
-    * @return
-    */
-  def filterAndSelectCorruptProxyRecords(scoredProxyRecords: DataFrame): DataFrame = {
-
-    val corruptProxyRecordsFilter = scoredProxyRecords(Score).equalTo(dataValidation.ScoreError)
-
-    scoredProxyRecords
-      .filter(corruptProxyRecordsFilter)
-      .select(OutSchema: _*)
   }
 
   val DefaultUserAgent = "-"

--- a/spot-ml/src/main/scala/org/apache/spot/proxy/ProxySuspiciousConnectsAnalysis.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/proxy/ProxySuspiciousConnectsAnalysis.scala
@@ -51,7 +51,7 @@ object ProxySuspiciousConnectsAnalysis {
       .na.fill(DefaultResponseContentType, Seq(ResponseContentType))
 
     logger.info("Fitting probabilistic model to data")
-    val model = ProxySuspiciousConnectsModel.trainNewModel(sparkContext, sqlContext, logger, config, proxyRecords)
+    val model = ProxySuspiciousConnectsModel.trainModel(sparkContext, sqlContext, logger, config, proxyRecords)
 
     logger.info("Identifying outliers")
     val scoredProxyRecords = model.score(sparkContext, proxyRecords)

--- a/spot-ml/src/main/scala/org/apache/spot/proxy/ProxySuspiciousConnectsModel.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/proxy/ProxySuspiciousConnectsModel.scala
@@ -110,11 +110,11 @@ object ProxySuspiciousConnectsModel {
     *                     UserAgent, RespCode (as defined in ProxySchema object).
     * @return ProxySuspiciousConnectsModel
     */
-  def trainNewModel(sparkContext: SparkContext,
-                    sqlContext: SQLContext,
-                    logger: Logger,
-                    config: SuspiciousConnectsConfig,
-                    inputRecords: DataFrame): ProxySuspiciousConnectsModel = {
+  def trainModel(sparkContext: SparkContext,
+                 sqlContext: SQLContext,
+                 logger: Logger,
+                 config: SuspiciousConnectsConfig,
+                 inputRecords: DataFrame): ProxySuspiciousConnectsModel = {
 
     logger.info("training new proxy suspcious connects model")
 

--- a/spot-ml/src/test/scala/org/apache/spot/dns/DNSSuspiciousConnectsAnalysisTest.scala
+++ b/spot-ml/src/test/scala/org/apache/spot/dns/DNSSuspiciousConnectsAnalysisTest.scala
@@ -54,7 +54,7 @@ class DNSSuspiciousConnectsAnalysisTest extends TestingSparkContextFlatSpec with
     ldaBeta = 1.001)
 
 
-  "dns supicious connects analysis" should "estimate correct probabilities in toy data with framelength anomaly" in {
+  "dns suspicious connects analysis" should "estimate correct probabilities in toy data with framelength anomaly" in {
 
     val logger = LogManager.getLogger("SuspiciousConnectsAnalysis")
     logger.setLevel(Level.WARN)
@@ -62,7 +62,7 @@ class DNSSuspiciousConnectsAnalysisTest extends TestingSparkContextFlatSpec with
     val anomalousRecord = DNSInput("May 20 2016 02:10:25.970987000 PDT", 1463735425L, 1, "172.16.9.132", "122.2o7.turner.com", "0x00000001", 1, 0)
     val typicalRecord = DNSInput("May 20 2016 02:10:25.970987000 PDT", 1463735425L, 168, "172.16.9.132", "122.2o7.turner.com", "0x00000001", 1, 0)
     val data = sqlContext.createDataFrame(Seq(anomalousRecord, typicalRecord, typicalRecord, typicalRecord, typicalRecord))
-    val model = DNSSuspiciousConnectsModel.trainNewModel(sparkContext, sqlContext, logger, testConfig, data, testConfig.topicCount)
+    val model = DNSSuspiciousConnectsModel.trainModel(sparkContext, sqlContext, logger, testConfig, data)
     val scoredData = model.score(sparkContext, sqlContext, data, testConfig.userDomain)
     val anomalyScore = scoredData.filter(scoredData(FrameLength) === 1).first().getAs[Double](Score)
     val typicalScores = scoredData.filter(scoredData(FrameLength) === 168).collect().map(_.getAs[Double](Score))
@@ -76,7 +76,7 @@ class DNSSuspiciousConnectsAnalysisTest extends TestingSparkContextFlatSpec with
   }
 
 
-  "dns supicious connects analysis" should "estimate correct probabilities in toy data with subdomain length anomaly" in {
+  "dns suspicious connects analysis" should "estimate correct probabilities in toy data with subdomain length anomaly" in {
 
     val logger = LogManager.getLogger("SuspiciousConnectsAnalysis")
     logger.setLevel(Level.WARN)
@@ -98,7 +98,7 @@ class DNSSuspiciousConnectsAnalysisTest extends TestingSparkContextFlatSpec with
       1,
       0)
     val data = sqlContext.createDataFrame(Seq(anomalousRecord, typicalRecord, typicalRecord, typicalRecord, typicalRecord))
-    val model = DNSSuspiciousConnectsModel.trainNewModel(sparkContext, sqlContext, logger, testConfig, data, testConfig.topicCount)
+    val model = DNSSuspiciousConnectsModel.trainModel(sparkContext, sqlContext, logger, testConfig, data)
     val scoredData = model.score(sparkContext, sqlContext, data, testConfig.userDomain)
     val anomalyScore = scoredData.
       filter(scoredData(QueryName) === "1111111111111111111111111111111111111111111111111111111111111.tinker.turner.com").
@@ -115,7 +115,7 @@ class DNSSuspiciousConnectsAnalysisTest extends TestingSparkContextFlatSpec with
   }
 
 
-  "filterAndSelectCleanDNSRecords" should "return data set without garbage" in {
+  "filterRecords" should "return data set without garbage" in {
 
     val cleanedDNSRecords = DNSSuspiciousConnectsAnalysis.filterRecords(testDNSRecords.inputDNSRecordsDF)
 
@@ -123,7 +123,7 @@ class DNSSuspiciousConnectsAnalysisTest extends TestingSparkContextFlatSpec with
     cleanedDNSRecords.schema.size should be(8)
   }
 
-  "filterAndSelectInvalidDNSRecords" should "return invalid records" in {
+  "filterInvalidRecords" should "return invalid records" in {
 
     val invalidDNSRecords = DNSSuspiciousConnectsAnalysis.filterInvalidRecords(testDNSRecords.inputDNSRecordsDF)
 
@@ -131,7 +131,7 @@ class DNSSuspiciousConnectsAnalysisTest extends TestingSparkContextFlatSpec with
     invalidDNSRecords.schema.size should be(8)
   }
 
-  "filterScoredDNSRecords" should "return records with score less or equal to threshold" in {
+  "filterScoredRecords" should "return records with score less or equal to threshold" in {
 
     val threshold = 10e-5
     val scoredDNSRecords = DNSSuspiciousConnectsAnalysis

--- a/spot-ml/src/test/scala/org/apache/spot/netflow/model/FlowSuspiciousConnectsModelTest.scala
+++ b/spot-ml/src/test/scala/org/apache/spot/netflow/model/FlowSuspiciousConnectsModelTest.scala
@@ -4,7 +4,6 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{Row, SQLContext}
 import org.apache.spot.SuspiciousConnectsArgumentParser.SuspiciousConnectsConfig
 import org.apache.spot.netflow.FlowSchema._
-import org.apache.spot.netflow.FlowSuspiciousConnectsAnalysis
 import org.apache.spot.testutils.TestingSparkContextFlatSpec
 import org.scalatest.Matchers
 
@@ -23,14 +22,6 @@ class FlowSuspiciousConnectsModelTest extends TestingSparkContextFlatSpec with M
     ldaMaxiterations = 20,
     ldaAlpha = 1.02,
     ldaBeta = 1.001)
-
-  "filterAndSelectCleanFlowRecords" should "return data set without garbage" in {
-
-    val cleanedFlowRecords = FlowSuspiciousConnectsAnalysis.filterAndSelectCleanFlowRecords(testFlowRecords.inputFlowRecordsDF)
-
-    cleanedFlowRecords.count should be(7)
-    cleanedFlowRecords.schema.size should be(17)
-  }
 
   def testFlowRecords = new {
     val sqlContext = new SQLContext(sparkContext)

--- a/spot-ml/src/test/scala/org/apache/spot/proxy/ProxySuspiciousConnectsAnalysisTest.scala
+++ b/spot-ml/src/test/scala/org/apache/spot/proxy/ProxySuspiciousConnectsAnalysisTest.scala
@@ -87,7 +87,7 @@ class ProxySuspiciousConnectsAnalysisTest extends TestingSparkContextFlatSpec wi
     val data = sqlContext.createDataFrame(Seq(anomalousRecord, typicalRecord, typicalRecord, typicalRecord, typicalRecord,
       typicalRecord, typicalRecord, typicalRecord, typicalRecord, typicalRecord))
 
-    val model = ProxySuspiciousConnectsModel.trainNewModel(sparkContext, sqlContext, logger, testConfigProxy, data)
+    val model = ProxySuspiciousConnectsModel.trainModel(sparkContext, sqlContext, logger, testConfigProxy, data)
 
     val scoredData = model.score(sparkContext, data)
 
@@ -108,7 +108,7 @@ class ProxySuspiciousConnectsAnalysisTest extends TestingSparkContextFlatSpec wi
   }
 
 
-  "filterAndSelectCleanProxyRecords" should "return data without garbage" in {
+  "filterRecords" should "return data without garbage" in {
 
     val cleanedProxyRecords = ProxySuspiciousConnectsAnalysis
       .filterRecords(testProxyRecords.inputProxyRecordsDF)
@@ -117,7 +117,7 @@ class ProxySuspiciousConnectsAnalysisTest extends TestingSparkContextFlatSpec wi
     cleanedProxyRecords.schema.size should be(19)
   }
 
-  "filterAndSelectInvalidProxyRecords" should "return invalir records" in {
+  "filterInvalidRecords" should "return invalir records" in {
 
     val invalidProxyRecords = ProxySuspiciousConnectsAnalysis
       .filterInvalidRecords(testProxyRecords.inputProxyRecordsDF)
@@ -127,7 +127,7 @@ class ProxySuspiciousConnectsAnalysisTest extends TestingSparkContextFlatSpec wi
 
   }
 
-  "filterScoredProxyRecords" should "return records with score less or equal to threshold" in {
+  "filterScoredRecords" should "return records with score less or equal to threshold" in {
 
     val threshold = 10e-5
 

--- a/spot-ml/src/test/scala/org/apache/spot/proxy/ProxyWordCreationTest.scala
+++ b/spot-ml/src/test/scala/org/apache/spot/proxy/ProxyWordCreationTest.scala
@@ -127,10 +127,9 @@ class ProxyWordCreationTest extends TestingSparkContextFlatSpec with Matchers {
       AlexaGetMidEntroTextPopularAgentMidUri302,
       AlexaGetHiEntroTextPopularAgentLargeUri302))
 
-    val scoredData = ProxySuspiciousConnectsAnalysis.detectProxyAnomalies(data, testConfigProxy,
-      sparkContext,
-      sqlContext,
-      logger)
+    val model = ProxySuspiciousConnectsModel.trainNewModel(sparkContext, sqlContext, logger, testConfigProxy, data)
+
+    val scoredData = model.score(sparkContext, data)
 
     val words = scoredData.collect().map(_.getAs[String](Word))
 

--- a/spot-ml/src/test/scala/org/apache/spot/proxy/ProxyWordCreationTest.scala
+++ b/spot-ml/src/test/scala/org/apache/spot/proxy/ProxyWordCreationTest.scala
@@ -127,7 +127,7 @@ class ProxyWordCreationTest extends TestingSparkContextFlatSpec with Matchers {
       AlexaGetMidEntroTextPopularAgentMidUri302,
       AlexaGetHiEntroTextPopularAgentLargeUri302))
 
-    val model = ProxySuspiciousConnectsModel.trainNewModel(sparkContext, sqlContext, logger, testConfigProxy, data)
+    val model = ProxySuspiciousConnectsModel.trainModel(sparkContext, sqlContext, logger, testConfigProxy, data)
 
     val scoredData = model.score(sparkContext, data)
 


### PR DESCRIPTION
This PR implements changes requested on JIRA issue SPOT-128. Includes the elimination of any call to save/write to file system in any place other than the main application.
Also, includes some code cleanup and refactoring.

#### Main changes

- [x] Modified the run method in each pipeline so that it returns two data frames, one with the final results (scored) and another with the invalid records. 

- [x] Removed any remaining call to save so that the only part of code writing to the file system is the main application.

- [x] Modified SuspiciousConnects main application to write the results from whatever pipeline is being analyzed.

#### Other code refactoring and cleanup:

- [x] Modified filter and select methods in each pipeline (*SuspiciousConnectsAnalysis.scala) to just return a set of clean or invalid records removing the select call in case users want to do further analysis and do not drop columns.

- [x] Removed the concept of corrupt records leaving only invalid records. Updated filtering/validations so only valid records are processed.

- [x] Code refactoring/consistency on *SuspiciousConnectsModel.scala changing trainNewModel to trainModel
- [x] Fixed a couple of typos in DNSSuspiciousConnectsAnalysisTest.scala