### PR TITLE
Spot-136 Number of executors is set but also dynamic allocation

### DIFF
--- a/spot-ml/ml_ops.sh
+++ b/spot-ml/ml_ops.sh
@@ -84,10 +84,10 @@ hdfs dfs -rm -R -f ${HDFS_SCORED_CONNECTS}
 time spark-submit --class "org.apache.spot.SuspiciousConnects" \
   --master yarn-client \
   --driver-memory ${SPK_DRIVER_MEM} \
-  --num-executors ${SPK_EXEC} \
   --conf spark.driver.maxResultSize=${SPK_DRIVER_MAX_RESULTS} \
   --conf spark.driver.maxPermSize=512m \
   --conf spark.dynamicAllocation.enabled=true \
+  --conf spark.dynamicAllocation.maxExecutors=${SPK_EXEC} \
   --conf spark.executor.cores=${SPK_EXEC_CORES} \
   --conf spark.executor.memory=${SPK_EXEC_MEM} \
   --conf "spark.executor.extraJavaOptions=-XX:MaxPermSize=512M -XX:PermSize=512M" \


### PR DESCRIPTION
Aims to close SPOT-136.

Removed --num-executors from ml_ops.sh and replaced with dynamicAllocation.maxExecutors for the maximum number of executors and stop getting Spark warning about ignoring --num-executors.
