### PR TITLE
Bug fix - The UI is not displaying the correct layout for internal/external IPs

### DIFF
--- a/spot-oa/api/graphql/flow/query.py
+++ b/spot-oa/api/graphql/flow/query.py
@@ -78,14 +78,14 @@ SuspiciousType = GraphQLObjectType(
             resolver=lambda root, *_: root.get('rank') or 0
         ),
         'srcIp_isInternal': GraphQLField(
-            type=GraphQLBoolean,
+            type=GraphQLInt,
             description='Internal source IP address context flag',
-            resolver=lambda root, *_: root.get('srcip_internal') == '1'
+            resolver=lambda root, *_: root.get('srcip_internal')
         ),
         'dstIp_isInternal': GraphQLField(
-            type=GraphQLBoolean,
+            type=GraphQLInt,
             description='Internal destionation IP address context flag',
-            resolver=lambda root, *_: root.get('dstip_internal') == '1'
+            resolver=lambda root, *_: root.get('dstip_internal')
         ),
         'srcIp_geoloc': GraphQLField(
             type=GraphQLString,

--- a/spot-oa/ui/dns/js/components/NetworkViewPanel.react.js
+++ b/spot-oa/ui/dns/js/components/NetworkViewPanel.react.js
@@ -46,7 +46,7 @@ function getNodesFromData(data) {
                 nodes[id] = {
                     id: id,
                     label: item[field],
-                    internalIp: field==='tld',
+                    internalIp: field==='tld' ? 1 : 0,
                     hits: 1
                 };
             }

--- a/spot-oa/ui/flow/js/components/NetworkViewPanel.react.js
+++ b/spot-oa/ui/flow/js/components/NetworkViewPanel.react.js
@@ -49,7 +49,7 @@ function getNodesFromData(data) {
                 nodes[id] = {
                     id: id,
                     label: item[field],
-                    internalIp: item[mapper[field]]==='1',
+                    internalIp: item[mapper[field]],
                     hits: 1
                 };
             }

--- a/spot-oa/ui/js/components/PolloNetworkViewMixin.react.js
+++ b/spot-oa/ui/js/components/PolloNetworkViewMixin.react.js
@@ -19,7 +19,7 @@ const PolloNetworkViewMixin = {
 
         // Node related scales
         const hitsDomain = [1, this.state.data.maxNodes];
-        const ipDomain = [false, true];
+        const ipDomain = [0,1];
         this.nodeSizeScale = d3.scale.linear().domain(hitsDomain);
         this.chargeScale = d3.scale.linear().domain(hitsDomain);
         this.typeScale = d3.scale.ordinal().domain(ipDomain).range(["circle", "diamond"]);


### PR DESCRIPTION
When ipranges.csv file is present during OA execution, the srcIPInternal and dstIPInternal fields are populated  accordingly. However, the UI is not displaying this information as expected. In the suspicious frame it should include all Internal IP Addresses as blue rectangle. In the Network View the Internal IP Addresses must be represented by blue diamonds
This also impacted the Network view for DNS