### PR TITLE
DE 121 - Bugfix to avoid the OA to halt when the FB reputation service is unreponsive

### DIFF
--- a/spot-oa/oa/dns/dns_oa.py
+++ b/spot-oa/oa/dns/dns_oa.py
@@ -229,8 +229,10 @@ class OA(object):
                 rep_results = {}            
                 for result in rep_services_results:            
                     rep_results = {k: "{0}::{1}".format(rep_results.get(k, ""), result.get(k, "")).strip('::') for k in set(rep_results) | set(result)}
-
-                self._dns_scores = [ conn + [ rep_results[conn[key]] ]   for conn in self._dns_scores  ]
+                
+                if rep_results:
+                    self._dns_scores = [ conn + [ rep_results[conn[key]] ]   for conn in self._dns_scores  ]
+                
         else:
             self._dns_scores = [ conn + [""]   for conn in self._dns_scores  ]
 

--- a/spot-oa/oa/proxy/proxy_oa.py
+++ b/spot-oa/oa/proxy/proxy_oa.py
@@ -218,7 +218,8 @@ class OA(object):
                 for result in rep_services_results:
                     rep_results = {k: "{0}::{1}".format(rep_results.get(k, ""), result.get(k, "")).strip('::') for k in set(rep_results) | set(result)}
 
-                self._proxy_scores = [ conn + [ rep_results[conn[key]] ]   for conn in self._proxy_scores  ]
+                if rep_results:
+                    self._proxy_scores = [ conn + [ rep_results[conn[key]] ]   for conn in self._proxy_scores  ]
         else:
             self._proxy_scores = [ conn + [""] for conn in self._proxy_scores  ]
 


### PR DESCRIPTION
When the FB threat exchange API is unresponsive, the reputation module responded with an empty dictionary, which caused the OA process to halt for DNS and Proxy