### PR TITLE
Spot-172 Proxy not returning the number of results requested

### DIFF
--- a/spot-ml/src/main/scala/org/apache/spot/SuspiciousConnects.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/SuspiciousConnects.scala
@@ -89,7 +89,15 @@ object SuspiciousConnects {
             import sparkSession.implicits._
             resultRecords.map(_.mkString(config.outputDelimiter)).rdd.saveAsTextFile(config.hdfsScoredConnect)
 
-            InputOutputDataHandler.mergeResultsFiles(sparkSession, config.hdfsScoredConnect, analysis, logger)
+            // SPOT-172: need to use FileSystem for proxy.
+            analysis match {
+              case "flow" => InputOutputDataHandler
+                .mergeResultsFileUtil(sparkSession, config.hdfsScoredConnect, analysis, logger)
+              case "dns" => InputOutputDataHandler
+                .mergeResultsFileUtil(sparkSession, config.hdfsScoredConnect, analysis, logger)
+              case "proxy" => InputOutputDataHandler
+                .mergeResultsFileSystem(sparkSession, config.hdfsScoredConnect, analysis, logger)
+            }
 
             InvalidDataHandler.showAndSaveInvalidRecords(invalidRecords, config.hdfsScoredConnect, logger)
           }

--- a/spot-ml/src/main/scala/org/apache/spot/SuspiciousConnects.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/SuspiciousConnects.scala
@@ -89,7 +89,8 @@ object SuspiciousConnects {
             import sparkSession.implicits._
             resultRecords.map(_.mkString(config.outputDelimiter)).rdd.saveAsTextFile(config.hdfsScoredConnect)
 
-            // SPOT-172: need to use FileSystem for proxy.
+            // SPOT-172 (https://issues.apache.org/jira/browse/SPOT-172)
+            // We need to use FileSystem for proxy.
             analysis match {
               case "flow" => InputOutputDataHandler
                 .mergeResultsFileUtil(sparkSession, config.hdfsScoredConnect, analysis, logger)

--- a/spot-ml/src/main/scala/org/apache/spot/utilities/data/InputOutputDataHandler.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/utilities/data/InputOutputDataHandler.scala
@@ -30,9 +30,9 @@ object InputOutputDataHandler {
 
   /**
     *
-    * @param spark     Spark Session.
-    * @param inputPath HDFS input folder for every execution; flow, dns or proxy.
-    * @param logger    Application logger.
+    * @param sparkSession Spark Session.
+    * @param inputPath    HDFS input folder for every execution; flow, dns or proxy.
+    * @param logger       Application logger.
     * @return raw data frame.
     */
   def getInputDataFrame(sparkSession: SparkSession, inputPath: String, logger: Logger): Option[DataFrame] = {
@@ -46,12 +46,15 @@ object InputOutputDataHandler {
 
   /**
     *
-    * @param spark             Spark Session.
+    * @param sparkSession      Spark Session.
     * @param hdfsScoredConnect HDFS output folder. The location where results were saved; flow, dns or proxy.
     * @param analysis          Data type to analyze.
     * @param logger            Application Logger.
     */
-  def mergeResultsFiles(sparkSession: SparkSession, hdfsScoredConnect: String, analysis: String, logger: Logger) {
+  def mergeResultsFileUtil(sparkSession: SparkSession,
+                           hdfsScoredConnect: String,
+                           analysis: String,
+                           logger: Logger): Unit = {
     val hadoopConfiguration = sparkSession.sparkContext.hadoopConfiguration
     val fileSystem = org.apache.hadoop.fs.FileSystem.get(hadoopConfiguration)
 
@@ -63,6 +66,54 @@ object InputOutputDataHandler {
       fileUtil.copyMerge(fileSystem, srcDir, fileSystem, dstFile, false, hadoopConfiguration, "")
 
       val files: RemoteIterator[LocatedFileStatus] = fileSystem.listFiles(srcDir, false)
+      while (files.hasNext) {
+        val filePath = files.next.getPath
+        if (filePath.toString.contains("part-")) {
+          fileSystem.delete(filePath, false)
+        }
+      }
+    }
+    else logger.info(s"Couldn't find results in $hdfsScoredConnect." +
+      s"Please check previous logs to see if there were errors.")
+  }
+
+  def mergeResultsFileSystem(sparkSession: SparkSession,
+                             hdfsScoredConnect: String,
+                             analysis: String,
+                             logger: Logger): Unit = {
+
+    val hadoopConfiguration = sparkSession.sparkContext.hadoopConfiguration
+    val fileSystem = org.apache.hadoop.fs.FileSystem.get(hadoopConfiguration)
+
+    val exists = fileSystem.exists(new org.apache.hadoop.fs.Path(hdfsScoredConnect))
+
+    if (exists) {
+      // SPOT-172. Seems like FilUtil.copyMerge is not behaving well with Proxy data. Besides, it's deprecated after
+      // Hadoop 2.7.x
+      // Using spark to merge result files
+      val tmpFileStr = s"${hdfsScoredConnect}/tmp"
+      val tmpPath = new Path(s"${hdfsScoredConnect}/tmp")
+
+      // File name after sparkContext.textFile.coalesce(1)
+      val singleFileName = "part-00000"
+
+      val srcPath = new Path(hdfsScoredConnect)
+      val srcPartsStr = s"${hdfsScoredConnect}/part-*"
+
+      val srcTmpPath = new Path(s"${tmpFileStr}/${singleFileName}")
+      val dstTmpPath = new Path(s"${hdfsScoredConnect}/${analysis}_results.csv")
+
+      // Merge all part-* into a single file
+      sparkSession.sparkContext.textFile(srcPartsStr).coalesce(1).saveAsTextFile(tmpFileStr)
+
+      // Rename the single file generated part-00000 to ${analysis}_results.csv
+      fileSystem.rename(srcTmpPath, dstTmpPath)
+
+      // Delete tmp folder
+      fileSystem.delete(tmpPath, true)
+
+      // Delete all part-* files in the same level as ${analysis}_results.csv
+      val files: RemoteIterator[LocatedFileStatus] = fileSystem.listFiles(srcPath, false)
       while (files.hasNext) {
         val filePath = files.next.getPath
         if (filePath.toString.contains("part-")) {

--- a/spot-ml/src/main/scala/org/apache/spot/utilities/data/InputOutputDataHandler.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/utilities/data/InputOutputDataHandler.scala
@@ -74,7 +74,7 @@ object InputOutputDataHandler {
       }
     }
     else logger.info(s"Couldn't find results in $hdfsScoredConnect." +
-      s"Please check previous logs to see if there were errors.")
+      s"Please check for SuspiciousConnects or Spark logs to see if there were errors.")
   }
 
   def mergeResultsFileSystem(sparkSession: SparkSession,
@@ -88,7 +88,8 @@ object InputOutputDataHandler {
     val exists = fileSystem.exists(new org.apache.hadoop.fs.Path(hdfsScoredConnect))
 
     if (exists) {
-      // SPOT-172. Seems like FilUtil.copyMerge is not behaving well with Proxy data. Besides, it's deprecated after
+      // SPOT-172 (https://issues.apache.org/jira/browse/SPOT-172)
+      // Seems like FilUtil.copyMerge is not behaving well with Proxy data. Besides, it's deprecated after
       // Hadoop 2.7.x
       // Using spark to merge result files
       val tmpFileStr = s"${hdfsScoredConnect}/tmp"
@@ -122,7 +123,7 @@ object InputOutputDataHandler {
       }
     }
     else logger.info(s"Couldn't find results in $hdfsScoredConnect." +
-      s"Please check previous logs to see if there were errors.")
+      s"Please check for SuspiciousConnects or Spark logs to see if there were errors.")
   }
 
 }


### PR DESCRIPTION
Implements a fix for SPOT-172.

#### Main changes
- Added new method to merge part-* files after Spark saves results as text. The new method using FileSystem is going to be used by Proxy which it was having issues with FileUtil.copyMerge.
- Did a quick refactor on scala docs of InputOutputDataHandler.scala, replaced spark with sparkSession.