### PR TITLE
Spot-168 Removing kerberos references

### DIFF
--- a/spot-setup/README.md
+++ b/spot-setup/README.md
@@ -24,7 +24,7 @@ The main script in the repository is **hdfs_setup.sh** which is responsible of l
 
 **spot.conf** is the file storing the variables needed during the installation process including node assignment, User interface, Machine Learning and Ingest gateway nodes.
 
-This file also contains sources desired to be installed as part of Apache Spot, general paths for HDFS folders, Kerberos information and local paths in the Linux filesystem for the user as well as for machine learning, ipython, lda and ingest processes.
+This file also contains sources desired to be installed as part of Apache Spot, general paths for HDFS folders, and local paths in the Linux filesystem for the user as well as for machine learning, ipython, lda and ingest processes.
 
 To read more about these variables, please review the [documentation] (http://spot.incubator.apache.org/doc/#configuration).
 

--- a/spot-setup/spot.conf
+++ b/spot-setup/spot.conf
@@ -17,13 +17,6 @@ HPATH=${HUSER}/${DSOURCE}/scored_results/${FDATE}
 IMPALA_DEM='node04'
 IMPALA_PORT=21050
 
-#kerberos config
-KRB_AUTH=false
-KINITPATH=
-KINITOPTS=
-KEYTABPATH=
-KRB_USER=
-
 #local fs base user and data source config
 LUSER='/home/spot'
 LPATH=${LUSER}/ml/${DSOURCE}/${FDATE}


### PR DESCRIPTION
Removing kerneros references from spot-setup
[Jira SPOT-168](https://issues.apache.org/jira/browse/SPOT-168)