### PR TITLE
De 127 scoring proxy

### DIFF
--- a/spot-oa/ui/proxy/js/components/NetworkViewPanel.react.js
+++ b/spot-oa/ui/proxy/js/components/NetworkViewPanel.react.js
@@ -375,7 +375,7 @@ var NetworkViewPanel = React.createClass({
                     0
                 );
             } else {
-                node.size = node.hits.length;
+                node.size = node.hits === undefined ? 0 : node.hits.length;
             }
 
             nodes.push(node);

--- a/spot-oa/ui/proxy/js/components/NetworkViewPanel.react.js
+++ b/spot-oa/ui/proxy/js/components/NetworkViewPanel.react.js
@@ -102,7 +102,7 @@ var NetworkViewPanel = React.createClass({
         // Delete old links
         this.link.exit().remove();
 
-        // Update nodes
+        // Update nodesw
         this.node = this.canvas.selectAll('.node, .proxy_node')
             .data(nodes.filter((node) => node.visible), function(d) { return d.id; });
 
@@ -261,7 +261,7 @@ var NetworkViewPanel = React.createClass({
                 type: 'Root',
                 tooltip: 'Double click to toggle child nodes',
                 rep: -1,
-                visible: true,
+                visible: state.data.length > 0 ? true : false,
                 expanded: false,
                 root: true
             };


### PR DESCRIPTION
Proxys scoring panel was hanging when a date with no data available was selected. At the same time, a unique 'root node' was being displayed in the network view.

This PR adds a couple of validations on the suspicious data to prevent this behavior