### PR TITLE
Bug fix - start_oa.py fails for single-digit dates

### DIFF
--- a/spot-oa/oa/dns/dns_oa.py
+++ b/spot-oa/oa/dns/dns_oa.py
@@ -393,7 +393,10 @@ class OA(object):
             df_results = pd.read_csv(results_file, delimiter=',') 
 
             # Forms a new dataframe splitting the minutes from the time column
-            df_new = pd.DataFrame([["{0}-{1}-{2} {3}:{4}".format(yr, mn, dy,val['frame_time'].split(" ")[3].split(":")[0].zfill(2),val['frame_time'].split(" ")[3].split(":")[1].zfill(2)), int(val['total']) if not math.isnan(val['total']) else 0 ] for key,val in df_results.iterrows()],columns = ingest_summary_cols)
+            df_new = pd.DataFrame([["{0}-{1}-{2} {3}:{4}".format(yr, mn, dy,\
+            val['frame_time'].replace("  "," ").split(" ")[3].split(":")[0].zfill(2),\
+            val['frame_time'].replace("  "," ").split(" ")[3].split(":")[1].zfill(2)),\
+            int(val['total']) if not math.isnan(val['total']) else 0 ] for key,val in df_results.iterrows()],columns = ingest_summary_cols)
     
             #Groups the data by minute 
             sf = df_new.groupby(by=['date'])['total'].sum()


### PR DESCRIPTION
Replaced all double spaces in timeframe column with a single space.
Aims to close:
https://issues.apache.org/jira/browse/SPOT-193
