### PR TITLE
Spot-197 Remove top 1m.csv file from repository

### DIFF
--- a/spot-ml/INSTALL.md
+++ b/spot-ml/INSTALL.md
@@ -9,7 +9,7 @@ The most important prerequisite for machine learning is the environment preparat
 - Unzip
 - Move complete folder to incubator-spot/spot-ml/
 
-After that it should looks like incubator-spot/spot-ml/top-1m.csv
+After that it should look like incubator-spot/spot-ml/top-1m.csv
 
 ## Prerequisites, Installation and Configuration
 

--- a/spot-ml/INSTALL.md
+++ b/spot-ml/INSTALL.md
@@ -2,6 +2,15 @@
 
 Machine learning routines for Apache Spot (incubating).
 
+## Required top-1m.csv
+
+The most important prerequisite for machine learning is the environment preparation with CSV file. Because of ml dependency with this CSV file, we have to follow next instructions: 
+- Download [CSV file](http://s3.amazonaws.com/alexa-static/top-1m.csv.zip)
+- Unzip
+- Move complete folder to incubator-spot/spot-ml/
+
+After that it should looks like incubator-spot/spot-ml/top-1m.csv
+
 ## Prerequisites, Installation and Configuration
 
 Install and configure spot-ml as a part of the Spot project, per the instruction at

--- a/spot-ml/README.md
+++ b/spot-ml/README.md
@@ -13,6 +13,10 @@ These routines are contained in a jar file   and there is a shell script ml_ops.
 * [jar documentation here](SPOT-ML-JAR.md)
 * [ml_ops.sh documentation here](ML_OPS.md) 
 
+## Essential
+
+Machine learning tools are oriented to provide a good functionality, and it will be possible only if we consider all components and prerequisites. The most important prerequisite for machine learning is the environment preparation with CSV file. Because of ml dependency with this CSV file, we have to follow the instructions specified in section of [Required top-1m.csv](INSTALL.md).      
+
 ## Configure the /etc/spot.conf file
 
 If using spot-ml as part of the integrated spot solution (or if you simply wish to use the ml_ops.sh script to invoke the suspicious connects analysis), 

--- a/spot-ml/src/main/scala/org/apache/spot/utilities/TopDomains.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/utilities/TopDomains.scala
@@ -25,9 +25,14 @@ import scala.io.Source
 object TopDomains {
   val alexaTop1MPath = "top-1m.csv"
 
-  val TopDomains: Set[String] = Source.fromFile(alexaTop1MPath).getLines.map(line => {
-    val parts = line.split(",")
-    val l = parts.length
-    parts(1).split('.')(0)
-  }).toSet
+  val TopDomains: Set[String] = if (new java.io.File(alexaTop1MPath).exists) {
+    Source.fromFile(alexaTop1MPath).getLines.map(line => {
+      val parts = line.split(",")
+      parts(1).split('.')(0)
+    }).toSet
+  } else {
+    // Default domains for unit testing only.
+    Set("spot-ml-unit-test-1", "spot-ml-unit-test-2", "spot-ml-unit-test-3", "spot-ml-unit-test-4")
+  }
+
 }

--- a/spot-ml/src/test/scala/org/apache/spot/dns/DNSSuspiciousConnectsModelTest.scala
+++ b/spot-ml/src/test/scala/org/apache/spot/dns/DNSSuspiciousConnectsModelTest.scala
@@ -10,8 +10,8 @@ class DNSSuspiciousConnectsModelTest extends TestingSparkContextFlatSpec with Ma
   "createTempFields" should "create DNS stats based on an URL" in {
     val countryCodesBC = sparkSession.sparkContext.broadcast(CountryCodes.CountryCodes)
     val topDomainsBC = sparkSession.sparkContext.broadcast(TopDomains.TopDomains)
-    val userDomain = "intel.com"
-    val url = "iot.intel.com.mx"
+    val userDomain = "spot-ml-unit-test-2.com"
+    val url = "iot.spot-ml-unit-test-2.com.mx"
 
 
     val result = DNSSuspiciousConnectsModel.createTempFields(countryCodesBC, topDomainsBC, userDomain, url)
@@ -27,7 +27,7 @@ class DNSSuspiciousConnectsModelTest extends TestingSparkContextFlatSpec with Ma
     val countryCodesBC = sparkSession.sparkContext.broadcast(CountryCodes.CountryCodes)
     val topDomainsBC = sparkSession.sparkContext.broadcast(TopDomains.TopDomains)
     val userDomain = "anothercompany.com"
-    val url = "maps.company.com"
+    val url = "maps.spot-ml-unit-test-3.com"
 
     val result = DNSSuspiciousConnectsModel.createTempFields(countryCodesBC, topDomainsBC, userDomain, url)
 

--- a/spot-ml/src/test/scala/org/apache/spot/proxy/ProxyWordCreationTest.scala
+++ b/spot-ml/src/test/scala/org/apache/spot/proxy/ProxyWordCreationTest.scala
@@ -70,47 +70,47 @@ class ProxyWordCreationTest extends TestingSparkContextFlatSpec with Matchers {
       "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
       "-", "127.0.0.1", 338, 647, "ab")
 
-    val AlexaPutMidEntroImagePopularAgentShortUri202 = ProxyInput("2016-10-03", "01:57:36", "127.0.0.1", "maw.bronto.com",
+    val AlexaPutMidEntroImagePopularAgentShortUri202 = ProxyInput("2016-10-03", "01:57:36", "127.0.0.1", "maw.spot-ml-unit-test-4.com",
       "PUT", "Safari/537.36", "image", 230, "-", "Technology/Internet", "http://www.spoonflower.com/tags/color", "202", 80,
       "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
       "-", "127.0.0.1", 338, 647, "abc")
 
-    val AlexaPutMidEntroImagePopularAgentShortUri304 = ProxyInput("2016-10-03", "02:57:36", "127.0.0.1", "maw.bronto.com",
+    val AlexaPutMidEntroImagePopularAgentShortUri304 = ProxyInput("2016-10-03", "02:57:36", "127.0.0.1", "maw.spot-ml-unit-test-4.com",
       "PUT", "Safari/537.36", "image", 230, "-", "Technology/Internet", "http://www.spoonflower.com/tags/color", "304", 80,
       "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
       "-", "127.0.0.1", 338, 647, "abcd")
 
-    val AlexaPutMidEntroBinaryPopularAgentShortUri304 = ProxyInput("2016-10-03", "03:57:36", "127.0.0.1", "maw.bronto.com",
+    val AlexaPutMidEntroBinaryPopularAgentShortUri304 = ProxyInput("2016-10-03", "03:57:36", "127.0.0.1", "maw.spot-ml-unit-test-4.com",
       "PUT", "Safari/537.36", "binary", 230, "-", "Technology/Internet", "http://www.spoonflower.com/tags/color", "304", 80,
       "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
       "-", "127.0.0.1", 338, 647, "abcde")
 
-    val AlexaPutMidEntroBinaryPopularAgentShortUri206 = ProxyInput("2016-10-03", "10:57:36", "127.0.0.1", "maw.bronto.com",
+    val AlexaPutMidEntroBinaryPopularAgentShortUri206 = ProxyInput("2016-10-03", "10:57:36", "127.0.0.1", "maw.spot-ml-unit-test-4.com",
       "PUT", "Safari/537.36", "binary", 230, "-", "Technology/Internet", "http://www.spoonflower.com/tags/color", "206", 80,
       "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
       "-", "127.0.0.1", 338, 647, "abcdef")
 
-    val AlexaGetHiEntroBinaryPopularAgentShortUri206 = ProxyInput("2016-10-03", "11:57:36", "127.0.0.1", "maw.bronto.com",
+    val AlexaGetHiEntroBinaryPopularAgentShortUri206 = ProxyInput("2016-10-03", "11:57:36", "127.0.0.1", "maw.spot-ml-unit-test-4.com",
       "GET", "Safari/537.36", "binary", 230, "-", "Technology/Internet", "http://www.spoonflower.com/tags/color", "206", 80,
       "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
       "-", "127.0.0.1", 338, 647, "abcdefghijklmnopqrstuvwxyz")
 
-    val AlexaGetZeroEntroTextPopularAgentShortUri200 = ProxyInput("2016-10-03", "13:57:36", "127.0.0.1", "maw.bronto.com",
+    val AlexaGetZeroEntroTextPopularAgentShortUri200 = ProxyInput("2016-10-03", "13:57:36", "127.0.0.1", "maw.spot-ml-unit-test-4.com",
       "GET", "Safari/537.36", "text/plain", 230, "-", "Technology/Internet", "http://www.spoonflower.com/tags/color", "200", 80,
       "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
       "-", "127.0.0.1", 338, 647, "aaa")
 
-    val AlexaGetLoEntroTextPopularAgentShortUri200 = ProxyInput("2016-10-03", "14:57:36", "127.0.0.1", "maw.bronto.com",
+    val AlexaGetLoEntroTextPopularAgentShortUri200 = ProxyInput("2016-10-03", "14:57:36", "127.0.0.1", "maw.spot-ml-unit-test-4.com",
       "GET", "Safari/537.36", "text/plain", 230, "-", "Technology/Internet", "http://www.spoonflower.com/tags/color", "200", 80,
       "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
       "-", "127.0.0.1", 338, 647, "aaabbb")
 
-    val AlexaGetMidEntroTextPopularAgentMidUri302 = ProxyInput("2016-10-03", "22:57:36", "127.0.0.1", "maw.bronto.com",
+    val AlexaGetMidEntroTextPopularAgentMidUri302 = ProxyInput("2016-10-03", "22:57:36", "127.0.0.1", "maw.spot-ml-unit-test-4.com",
       "GET", "Safari/537.36", "text/plain", 230, "-", "Technology/Internet", "http://www.spoonflower.com/tags/color", "302", 80,
       "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
       "-", "127.0.0.1", 338, 647, "aaaaaaaaaaabbbbbbbbbbbccccccccccc")
 
-    val AlexaGetHiEntroTextPopularAgentLargeUri302 = ProxyInput("2016-10-03", "23:57:36", "127.0.0.1", "maw.bronto.com",
+    val AlexaGetHiEntroTextPopularAgentLargeUri302 = ProxyInput("2016-10-03", "23:57:36", "127.0.0.1", "maw.spot-ml-unit-test-4.com",
       "GET", "Safari/537.36", "text/plain", 230, "-", "Technology/Internet", "http://www.spoonflower.com/tags/color", "302",
       80, "/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts/4b3a313d-50f6-4117-8ffd-4e804fd354ef/fiddle",
       "-", "127.0.0.1", 338, 647, "maw.bronto.com/sites/c37i4q22szvir8ga3m8mtxaft7gwnm5fio8hfxo35mu81absi1/carts" +

--- a/spot-ml/src/test/scala/org/apache/spot/utilities/DomainProcessorTest.scala
+++ b/spot-ml/src/test/scala/org/apache/spot/utilities/DomainProcessorTest.scala
@@ -85,7 +85,7 @@ class DomainProcessorTest extends TestingSparkContextFlatSpec with Matchers {
 
   it should "handle an Alexa top 1M domain with a subdomain, top-level domain name and country code" in {
 
-    val url = "services.amazon.com.mx"
+    val url = "services.spot-ml-unit-test-1.com.mx"
 
     val topDomains = sparkSession.sparkContext.broadcast(TopDomains.TopDomains)
 
@@ -93,45 +93,45 @@ class DomainProcessorTest extends TestingSparkContextFlatSpec with Matchers {
 
     val result = extractDomainInfo(url, topDomains, userDomain)
 
-    result shouldBe DomainInfo(domain = "amazon", topDomain = 1, subdomain = "services",
+    result shouldBe DomainInfo(domain = "spot-ml-unit-test-1", topDomain = 1, subdomain = "services",
       subdomainLength = 8, subdomainEntropy = 2.5, numPeriods = 4)
   }
 
   it should "handle an Alexa top 1M domain with a top-level domain name and country code but no subdomain" in {
 
-    val url = "amazon.com.mx"
+    val url = "spot-ml-unit-test-1.com.mx"
     val countryCodes = sparkSession.sparkContext.broadcast(countryCodesSet)
     val topDomains = sparkSession.sparkContext.broadcast(TopDomains.TopDomains)
     val userDomain = "intel"
 
     val result = extractDomainInfo(url, topDomains, userDomain)
 
-    result shouldBe DomainInfo(domain = "amazon", subdomain = "None", topDomain = 1, subdomainLength = 0, subdomainEntropy = 0, numPeriods = 3)
+    result shouldBe DomainInfo(domain = "spot-ml-unit-test-1", subdomain = "None", topDomain = 1, subdomainLength = 0, subdomainEntropy = 0, numPeriods = 3)
   }
 
   it should "handle an Alexa top 1M domain with a subdomain and top-level domain name but no country code" in {
 
-    val url = "services.amazon.com"
+    val url = "services.spot-ml-unit-test-1.com"
     val countryCodes = sparkSession.sparkContext.broadcast(countryCodesSet)
     val topDomains = sparkSession.sparkContext.broadcast(TopDomains.TopDomains)
     val userDomain = "intel"
 
     val result = extractDomainInfo(url, topDomains, userDomain)
 
-    result shouldBe DomainInfo(domain = "amazon", subdomain = "services", topDomain = 1, subdomainLength = 8, subdomainEntropy = 2.5, numPeriods = 3)
+    result shouldBe DomainInfo(domain = "spot-ml-unit-test-1", subdomain = "services", topDomain = 1, subdomainLength = 8, subdomainEntropy = 2.5, numPeriods = 3)
   }
 
 
   it should "handle an Alexa top 1M domain with no subdomain or country code" in {
 
-    val url = "amazon.com"
+    val url = "spot-ml-unit-test-1.com"
     val countryCodes = sparkSession.sparkContext.broadcast(countryCodesSet)
     val topDomains = sparkSession.sparkContext.broadcast(TopDomains.TopDomains)
     val userDomain = "intel"
 
     val result = extractDomainInfo(url, topDomains, userDomain)
 
-    result shouldBe DomainInfo(domain = "amazon", subdomain = "None", topDomain = 1, subdomainLength = 0, subdomainEntropy = 0, numPeriods = 2)
+    result shouldBe DomainInfo(domain = "spot-ml-unit-test-1", subdomain = "None", topDomain = 1, subdomainLength = 0, subdomainEntropy = 0, numPeriods = 2)
   }
   it should "not identify the domain as the users domain when both are empty strings" in {
     val url = "ab..com"


### PR DESCRIPTION
Implements changes requested on SPOT-197. Eliminates top-1m.csv file from repository and let's the user to download and save the most current version from AWS. 

**Main changes**

- Removed top-1m.csv from spot-ml folder/repository
- Updated code to validate if top-1m.csv file is present
- Updated unit testing to work with file not present
- Updated documentation to explain how to get top-1m.csv file and where to install.
