### PR TITLE
SPOT-220 SBT 0.14.x not working

### DIFF
--- a/spot-ml/project/build.properties
+++ b/spot-ml/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 0.13.11


### PR DESCRIPTION
Adding build.properties so SBT resolves the required version of SBT first and then it's able to assembly.