### PR TITLE
Spot 235 fix deprecated links in odm setup

### DIFF
--- a/spot-oa/arcadia/README.md
+++ b/spot-oa/arcadia/README.md
@@ -61,7 +61,10 @@ which is intended to be located in the /etc directory by default.
 
 1. run wget http://get.arcadiadata.com.s3.amazonaws.com/spot/sample/odm_sample_setup.sh to retrieve the sample data setup script.
 2. run chmod +x odm_sample_setup.sh to make the script executable.
-3. run ./odm_sample_setup.sh to retrieve, store, and make sample data available in your ODM tables.
+3. run `./odm_sample_setup.sh pqt` or `./odm_sample_setup.sh avro` to retrieve, store, and make sample data available in your ODM tables in the appropriate format.
+
+NOTE: Your sample data format should match the storage format of your ODM tables.
+For example, if you've created your ODM tables to store data as Parquet, run the sample script with the "pqt" argument.
 
 ## Licensing
 

--- a/spot-setup/odm/README.md
+++ b/spot-setup/odm/README.md
@@ -30,7 +30,7 @@ and finally execute hive query scripts that creates Hive tables needed to access
 
 **spot.conf** is the file storing the variables needed during the installation process including node assignment, User interface, Machine Learning and Ingest gateway nodes.
 This file also contains sources desired to be installed as part of Apache Spot, general paths for HDFS folders, Kerberos information and local paths in the Linux filesystem for the user as well as for machine learning, ipython, lda and ingest processes.
-To read more about these variables, please review the [wiki] (https://github.com/Open-Network-Insight/open-network-insight/wiki/Edit%20Solution%20Configuration).
+To read more about these variables, please review the [wiki] (http://spot.incubator.apache.org/doc/#configuration).
 
 By default, **odm_setup.sh** expects **spot.conf** to be located in the **/etc** directory on the node. An example spot.conf file is provided in the spot-setup parent directory to help you get started.
 
@@ -64,5 +64,5 @@ Create a pull request and contact the maintainers.
 
 ## Issues
 
-Report issues at the Apache Spot [issues] (https://github.com/Open-Network-Insight/open-network-insight/issues) page.
+Report issues at the Apache Spot [issues] (https://issues.apache.org/jira/projects/SPOT/issues) page.
 

--- a/spot-setup/odm/README.md
+++ b/spot-setup/odm/README.md
@@ -30,7 +30,7 @@ and finally execute hive query scripts that creates Hive tables needed to access
 
 **spot.conf** is the file storing the variables needed during the installation process including node assignment, User interface, Machine Learning and Ingest gateway nodes.
 This file also contains sources desired to be installed as part of Apache Spot, general paths for HDFS folders, Kerberos information and local paths in the Linux filesystem for the user as well as for machine learning, ipython, lda and ingest processes.
-To read more about these variables, please review the [wiki] (http://spot.incubator.apache.org/doc/#configuration).
+To read more about these variables, please review the [wiki](http://spot.incubator.apache.org/doc/#configuration).
 
 By default, **odm_setup.sh** expects **spot.conf** to be located in the **/etc** directory on the node. An example spot.conf file is provided in the spot-setup parent directory to help you get started.
 
@@ -64,5 +64,5 @@ Create a pull request and contact the maintainers.
 
 ## Issues
 
-Report issues at the Apache Spot [issues] (https://issues.apache.org/jira/projects/SPOT/issues) page.
+Report issues at the Apache Spot [issues](https://issues.apache.org/jira/projects/SPOT/issues) page.
 


### PR DESCRIPTION
- Old ONI wiki and issue links were changed and committed to use the new Spot links, but for some reason the changes didn't take after the PR (https://github.com/apache/incubator-spot/pull/119)
- Also made a small update in the arcadia/README.md instructions for loading sample data.  Sample data loading use the "odm_sample_setup.sh" script now requires a format argument to ensure sample data is loaded into the ODM tables properly (i.e. `./odm_sample_setup.sh pqt` or `./odm_sample_setup.sh avro`).