### PR TITLE
SPOT-238 Fix dns_oa.py to stop crashing FBThreatExchange

### DIFF
--- a/spot-oa/oa/dns/dns_oa.py
+++ b/spot-oa/oa/dns/dns_oa.py
@@ -232,7 +232,7 @@ class OA(object):
                     rep_results = {k: "{0}::{1}".format(rep_results.get(k, ""), result.get(k, "")).strip('::') for k in set(rep_results) | set(result)}
 
                 if rep_results:
-                    self._dns_scores = [ conn + [ rep_results[conn[key]] ]   for conn in self._dns_scores  ]
+                    self._dns_scores = [ conn + [ rep_results.get(key) ]    for conn in self._dns_scores  ]
                 else:
                     self._dns_scores = [ conn + [""]   for conn in self._dns_scores  ]
         else:


### PR DESCRIPTION
Stop the start_oa.py script from crashing, while performing reputation check for the dns_results.csv domains. 
https://issues.apache.org/jira/browse/SPOT-238