### PR TITLE
Spot 244 enable cors on graphql api

### DIFF
--- a/spot-oa/api/graphql/webapp.py
+++ b/spot-oa/api/graphql/webapp.py
@@ -22,6 +22,7 @@ if __name__=='__main__':
 
 from flask import Flask, Blueprint
 from flask_graphql import GraphQLView
+from flask_cors import CORS
 import os
 
 from schema import SpotSchema
@@ -32,6 +33,10 @@ blueprint = Blueprint('graphql_api', __name__)
 blueprint.add_url_rule('/graphql', strict_slashes=False, view_func=GraphQLView.as_view('graphql', schema=SpotSchema, graphiql=os.environ.get('SPOT_DEV')=='1'))
 
 app.register_blueprint(blueprint)
+
+# Configure CORS
+origins = os.environ.get('ACCESS_CONTROL_ALLOW_ORIGIN').split(",")
+CORS(app, origins=origins)
 
 if __name__=='__main__':
     port = int(sys.argv[1]) if len(sys.argv)>1 else 8889

--- a/spot-oa/requirements.txt
+++ b/spot-oa/requirements.txt
@@ -16,6 +16,7 @@ ipython == 3.2.1
 # GraphQL API dependencies
 flask
 flask-graphql
+flask-cors
 graphql-core
 urllib3
 

--- a/spot-setup/spot.conf
+++ b/spot-setup/spot.conf
@@ -60,3 +60,15 @@ PRECISION='64'
 TOL='1e-6'
 TOPIC_COUNT=20
 DUPFACTOR=1000
+
+# API CORS Options
+#
+#   ACCESS_CONTROL_ALLOW_ORIGIN:
+#       Configuration type: string or comma seperated list
+#
+#   Examples:
+#   '*' = Allow any origin (Default)
+#   'http://trustedresource.com' = Allow specific origin
+#   'http://trustedresource.com,http://anothertrustedresource.com' = Allow multiple origins
+#
+ACCESS_CONTROL_ALLOW_ORIGIN='*'


### PR DESCRIPTION
Enabling CORS with the ability to configure origins allows additional applications to use and support the Spot GraphQL API.

Tasks
- Add "flask-cors" to requirements.txt
- Use CORS with GraphQL app blueprint
- Add a configuration in spot.conf for origin specification