### PR TITLE
Spot 243 Specify graphql-core version 1.1 support

### DIFF
--- a/spot-oa/requirements.txt
+++ b/spot-oa/requirements.txt
@@ -16,7 +16,7 @@ ipython == 3.2.1
 # GraphQL API dependencies
 flask
 flask-graphql
-graphql-core
+graphql-core == 1.1.0
 urllib3
 
 # API Resources


### PR DESCRIPTION
There seem to be backwards incompatibilities with graphql-core 2+ and we need to ensure that the version installed is 1.1 for everything to work properly.