### PR TITLE
SPOT-261. ODM event schema additional_attrs field should be map<string>

### DIFF
--- a/spot-setup/odm/event.avsc
+++ b/spot-setup/odm/event.avsc
@@ -41,7 +41,7 @@
         {"name":"sensitivity", "type":["null","string"],"doc":"Sensitivity label", "default": null},
         {"name":"count", "type":["null","int"],"doc":"Generic count", "default": null},
         {"name":"company", "type":["null","string"],"doc":"Company label", "default": null},
-        {"name":"additional_attrs","type":["null","string"],"default":null, "doc":"Additional attributes of the event"},
+        {"name":"additional_attrs","type":["null", {"type": "map", "values": "string"}],"default":null, "doc":"Additional attributes of the event"},
         {"name":"totrust", "type":["null","string"],"doc":"TBD", "default": null},
         {"name":"fromtrust", "type":["null","string"],"doc":"TBD", "default": null},
         {"name":"rule", "type":["null","string"],"doc":"TBD", "default": null},


### PR DESCRIPTION
The Avro and Parquet table schemas designate the additional_attrs field as a map<string, string>, but in the Avro schema definition (in event.avsc), the field is listed as just an optional string. This field should be updated to be an optional map<string>