### PR TITLE
Spot 263 add kerberos support for odm setup

### DIFF
--- a/spot-setup/odm/odm_setup.sh
+++ b/spot-setup/odm/odm_setup.sh
@@ -24,6 +24,28 @@
 #   
 #   NOTE: At this time only Parquet and Avro storage formats are supported for the ODM tables.
 
+
+set -e
+
+function log() {
+    # General logger for the ODM setup script that prints any input provided to it
+    printf "hdfs_setup.sh:\n $1\n"
+}
+
+function safe_mkdir() {
+    # 1. Takes the hdfs command options and a directory
+    # 2. Checks for the directory before trying to create it and keeps the script from creating existing directories
+
+    local hdfs_cmd=$1
+    local dir=$2
+    if $(hdfs dfs -test -d ${dir}); then
+        log "${dir} already exists"
+    else
+        log "running mkdir on ${dir}"
+        ${hdfs_cmd} dfs -mkdir ${dir}
+    fi
+}
+
 # Check the format argument and make sure its supported
 format=$1
 if [ "$format" != "pqt" ] && [ "$format" != "avro" ] ; then

--- a/spot-setup/odm/odm_setup.sh
+++ b/spot-setup/odm/odm_setup.sh
@@ -46,13 +46,6 @@ function safe_mkdir() {
     fi
 }
 
-# Check the format argument and make sure its supported
-format=$1
-if [ "$format" != "pqt" ] && [ "$format" != "avro" ] ; then
-    echo "Format argument '$format' is not supported. Only Parquet and Avro are supported data storage formats. Use 'pqt' or 'avro'  instead (i.e. ./odm_setup pqt)."
-    exit 0
-fi
-
 SPOTCONF="/etc/spot.conf"
 DSOURCES=('odm')
 DFOLDERS=(
@@ -63,6 +56,34 @@ DFOLDERS=(
 'threat_intelligence_context'
 'vulnerability_context'
 )
+
+# Check input argument options
+for arg in "$@"; do
+    case $arg in
+        "--no-sudo")
+            log "not using sudo"
+            no_sudo=true
+            shift
+            ;;
+        "-c")
+            shift
+            SPOTCONF=$1
+            log "Spot Configuration file: ${SPOTCONF}"
+            shift
+            ;;
+        "-f")
+            shift
+            format=$1
+            shift
+            ;;
+    esac
+done
+
+# Check the format argument and make sure its supported
+if [ "$format" != "pqt" ] && [ "$format" != "avro" ] ; then
+    log "Format argument '$format' is not supported. Only Parquet and Avro are supported data storage formats. Use 'pqt' or 'avro'  instead (i.e. ./odm_setup pqt)."
+    exit 1
+fi
 
 # Sourcing ODM Spot configuration variables
 source /etc/spot.conf

--- a/spot-setup/odm/odm_setup.sh
+++ b/spot-setup/odm/odm_setup.sh
@@ -104,33 +104,34 @@ else
 fi
 
 # Creating HDFS user's folder
-sudo -u hdfs hdfs dfs -mkdir ${HUSER}
-sudo -u hdfs hdfs dfs -chown ${USER}:supergroup ${HUSER}
-sudo -u hdfs hdfs dfs -chmod 775 ${HUSER}
+log "creating ${HUSER}"
+safe_mkdir ${hdfs_cmd} ${HUSER}
+${hdfs_cmd} dfs -chown ${USER}:supergroup ${HUSER}
+${hdfs_cmd} dfs -chmod 775 ${HUSER}
 
 # Creating HDFS paths for each use case
 for d in "${DSOURCES[@]}" 
 do 
-	echo "creating /$d"
-	sudo -u hdfs hdfs dfs -mkdir ${HUSER}/$d 
+	log "creating /$d"
+	safe_mkdir hdfs ${HUSER}/$d
     
     # Create Avro schemas directory on HDFS if Avro storage is selected
     if [ "$format" == "avro" ] ; then
-        echo "creating /$d/schema"
-        sudo -u hdfs hdfs dfs -mkdir ${HUSER}/$d/schema
+        log "creating ${HUSER}/$d/schema"
+        safe_mkdir ${hdfs_cmd} ${HUSER}/$d/schema
     fi
 
 	for f in "${DFOLDERS[@]}" 
 	do 
-		echo "creating $d/$f"
-		sudo -u hdfs hdfs dfs -mkdir ${HUSER}/$d/$f
+		log "creating ${HUSER}/$d/$f"
+		safe_mkdir ${hdfs_cmd} ${HUSER}/$d/$f
 	done
 
 	# Modifying permission on HDFS folders to allow Impala to read/write
-    echo "modifying permissions recursively on ${HUSER}/$d"
-	sudo -u hdfs hdfs dfs -chmod -R 775 ${HUSER}/$d
-	sudo -u hdfs hdfs dfs -setfacl -R -m user:impala:rwx ${HUSER}/$d
-	sudo -u hdfs hdfs dfs -setfacl -R -m user:${USER}:rwx ${HUSER}/$d
+    log "modifying permissions recursively on ${HUSER}/$d"
+	hdfs dfs -chmod -R 775 ${HUSER}/$d
+	${hdfs_cmd} dfs -setfacl -R -m user:impala:rwx ${HUSER}/$d
+	${hdfs_cmd} dfs -setfacl -R -m user:${USER}:rwx ${HUSER}/$d
 done
 
 # Creating Spot Database

--- a/spot-setup/odm/odm_setup.sh
+++ b/spot-setup/odm/odm_setup.sh
@@ -134,8 +134,22 @@ do
 	${hdfs_cmd} dfs -setfacl -R -m user:${USER}:rwx ${HUSER}/$d
 done
 
+# Check if Kerberos is enabled, and create the proper impala-shell configuration and arguments to be used when creating the ODM tables
+
+log "Using Impala as execution engine."
+impala_db_shell="impala-shell -i ${IMPALA_DEM}"
+log "${impala_db_shell}"
+
+if [[ ${KERBEROS} == "true" ]]; then
+    log "Kerberos enabled. Modifying Impala Shell arguments"
+    impala_db_shell="${impala_db_shell} -k"
+    log "${impala_db_shell}"
+fi
+
 # Creating Spot Database
-impala-shell -i ${IMPALA_DEM} -q "CREATE DATABASE IF NOT EXISTS ${DBNAME};"
+
+log "CREATE DATABASE IF NOT EXISTS ${DBNAME};"
+${impala_db_shell} "CREATE DATABASE IF NOT EXISTS ${DBNAME}";
 
 # Creating ODM Impala tables
 for d in "${DSOURCES[@]}" 

--- a/spot-setup/odm/odm_setup.sh
+++ b/spot-setup/odm/odm_setup.sh
@@ -89,6 +89,20 @@ fi
 log "Sourcing ${SPOTCONF}\n"
 source $SPOTCONF
 
+# Check no-sudo argument and set the proper hdfs command to run our create table statements later
+if [[ ${no_sudo} == "true" ]]; then
+    hdfs_cmd="hdfs"
+
+    if [[ ! -z "${HADOOP_USER_NAME}" ]]; then
+        log "HADOOP_USER_NAME: ${HADOOP_USER_NAME}"
+    else
+        log "setting HADOOP_USER_NAME to hdfs"
+        HADOOP_USER_NAME=hdfs
+    fi
+else
+    hdfs_cmd="sudo -u hdfs hdfs"
+fi
+
 # Creating HDFS user's folder
 sudo -u hdfs hdfs dfs -mkdir ${HUSER}
 sudo -u hdfs hdfs dfs -chown ${USER}:supergroup ${HUSER}

--- a/spot-setup/odm/odm_setup.sh
+++ b/spot-setup/odm/odm_setup.sh
@@ -53,6 +53,7 @@ if [ "$format" != "pqt" ] && [ "$format" != "avro" ] ; then
     exit 0
 fi
 
+SPOTCONF="/etc/spot.conf"
 DSOURCES=('odm')
 DFOLDERS=(
 'event' 

--- a/spot-setup/odm/odm_setup.sh
+++ b/spot-setup/odm/odm_setup.sh
@@ -152,28 +152,32 @@ log "CREATE DATABASE IF NOT EXISTS ${DBNAME};"
 ${impala_db_shell} "CREATE DATABASE IF NOT EXISTS ${DBNAME}";
 
 # Creating ODM Impala tables
+
 for d in "${DSOURCES[@]}" 
 do 
     for f in "${DFOLDERS[@]}" 
 	do 
-        #If desired storage format is parquet, create ODM as Parquet tables
+        # If desired storage format is parquet, create ODM as Parquet tables
+
         if [ "$format" == "pqt" ] ; then
-            echo "Creating ODM Impala Parquet table ${f}..."
-            echo "impala-shell -i ${IMPALA_DEM} --var=ODM_DBNAME=${DBNAME} --var=ODM_TABLENAME=${f} --var=ODM_LOCATION=${HUSER}/${d}/${f} -c -f create_${f}_pqt.sql"
-            
-            impala-shell -i ${IMPALA_DEM} --var=ODM_DBNAME=${DBNAME} --var=ODM_TABLENAME=${f} --var=ODM_LOCATION=${HUSER}/${d}/${f} -c -f create_${f}_pqt.sql
+            log "Creating ODM Impala Parquet table ${f}..."
+            log "${impala_db_shell} --var=ODM_DBNAME=${DBNAME} --var=ODM_TABLENAME=${f} --var=ODM_LOCATION=${HUSER}/${d}/${f} -c -f create_${f}_pqt.sql"
+
+            ${impala_db_shell} --var=ODM_DBNAME=${DBNAME} --var=ODM_TABLENAME=${f} --var=ODM_LOCATION=${HUSER}/${d}/${f} -c -f create_${f}_pqt.sql
         fi
-        # If desired storage format is "avro", create ODM as Avro tables with Avro schemas
+
+        # If desired storage format is avro, create ODM as Avro tables with Avro schemas
+
         if [ "$format" == "avro" ] ; then
-            echo "Adding ${f} Avro schema to ${HUSER}/$d/schema ..."
-            echo "sudo -u ${USER} hdfs dfs -put -f $f.avsc ${HUSER}/$d/schema/$f.avsc"
+            log "Adding ${f} Avro schema to ${HUSER}/$d/schema ..."
+            log "${hdfs_cmd} dfs -put -f $f.avsc ${HUSER}/$d/schema/$f.avsc"
             
-            sudo -u ${USER} hdfs dfs -put -f $f.avsc ${HUSER}/$d/schema/$f.avsc
+            ${hdfs_cmd} dfs -put -f $f.avsc ${HUSER}/$d/schema/$f.avsc
         
-            echo "Creating ODM Impala Avro table ${f}..."
-            echo "impala-shell -i ${IMPALA_DEM} --var=ODM_DBNAME=${DBNAME} --var=ODM_TABLENAME=${f} --var=ODM_LOCATION=${HUSER}/${d}/${f} --var=ODM_AVRO_URL=hdfs://${HUSER}/${d}/schema/${f}.avsc -c -f create_${f}_avro.sql"
+            log "Creating ODM Impala Avro table ${f}..."
+            log "${impala_db_shell} --var=ODM_DBNAME=${DBNAME} --var=ODM_TABLENAME=${f} --var=ODM_LOCATION=${HUSER}/${d}/${f} --var=ODM_AVRO_URL=hdfs://${HUSER}/${d}/schema/${f}.avsc -c -f create_${f}_avro.sql"
         
-            impala-shell -i ${IMPALA_DEM} --var=ODM_DBNAME=${DBNAME} --var=ODM_TABLENAME=${f} --var=ODM_LOCATION=${HUSER}/${d}/${f} --var=ODM_AVRO_URL=hdfs://${HUSER}/${d}/schema/${f}.avsc -c -f create_${f}_avro.sql
+            ${impala_db_shell} --var=ODM_DBNAME=${DBNAME} --var=ODM_TABLENAME=${f} --var=ODM_LOCATION=${HUSER}/${d}/${f} --var=ODM_AVRO_URL=hdfs://${HUSER}/${d}/schema/${f}.avsc -c -f create_${f}_avro.sql
         fi
 	done
 done

--- a/spot-setup/odm/odm_setup.sh
+++ b/spot-setup/odm/odm_setup.sh
@@ -85,8 +85,9 @@ if [ "$format" != "pqt" ] && [ "$format" != "avro" ] ; then
     exit 1
 fi
 
-# Sourcing ODM Spot configuration variables
-source /etc/spot.conf
+# Sourcing spot configuration variables
+log "Sourcing ${SPOTCONF}\n"
+source $SPOTCONF
 
 # Creating HDFS user's folder
 sudo -u hdfs hdfs dfs -mkdir ${HUSER}

--- a/spot-setup/odm/odm_setup.sh
+++ b/spot-setup/odm/odm_setup.sh
@@ -137,7 +137,7 @@ do
 
 	# Modifying permission on HDFS folders to allow Impala to read/write
     log "modifying permissions recursively on ${HUSER}/$d"
-	hdfs dfs -chmod -R 775 ${HUSER}/$d
+	${hdfs_cmd} dfs -chmod -R 775 ${HUSER}/$d
 	${hdfs_cmd} dfs -setfacl -R -m user:impala:rwx ${HUSER}/$d
 	${hdfs_cmd} dfs -setfacl -R -m user:${USER}:rwx ${HUSER}/$d
 done

--- a/spot-setup/odm/odm_setup.sh
+++ b/spot-setup/odm/odm_setup.sh
@@ -44,8 +44,8 @@ function safe_mkdir() {
     # 1. Takes the hdfs command options and a directory
     # 2. Checks for the directory before trying to create it and keeps the script from creating existing directories
 
-    local hdfs_cmd=$1
-    local dir=$2
+    local hdfs_cmd="$1"
+    local dir="$2"
     if $(hdfs dfs -test -d ${dir}); then
         log "${dir} already exists"
     else
@@ -113,7 +113,7 @@ fi
 
 # Creating HDFS user's folder
 log "creating ${HUSER}"
-safe_mkdir ${hdfs_cmd} ${HUSER}
+safe_mkdir "${hdfs_cmd}" "${HUSER}"
 ${hdfs_cmd} dfs -chown ${USER}:supergroup ${HUSER}
 ${hdfs_cmd} dfs -chmod 775 ${HUSER}
 
@@ -121,18 +121,18 @@ ${hdfs_cmd} dfs -chmod 775 ${HUSER}
 for d in "${DSOURCES[@]}" 
 do 
 	log "creating /$d"
-	safe_mkdir hdfs ${HUSER}/$d
+	safe_mkdir "${hdfs_cmd}" "${HUSER}/$d"
     
     # Create Avro schemas directory on HDFS if Avro storage is selected
     if [ "$format" == "avro" ] ; then
         log "creating ${HUSER}/$d/schema"
-        safe_mkdir ${hdfs_cmd} ${HUSER}/$d/schema
+        safe_mkdir "${hdfs_cmd}" "${HUSER}/$d/schema"
     fi
 
 	for f in "${DFOLDERS[@]}" 
 	do 
 		log "creating ${HUSER}/$d/$f"
-		safe_mkdir ${hdfs_cmd} ${HUSER}/$d/$f
+		safe_mkdir "${hdfs_cmd}" "${HUSER}/$d/$f"
 	done
 
 	# Modifying permission on HDFS folders to allow Impala to read/write

--- a/spot-setup/odm/odm_setup.sh
+++ b/spot-setup/odm/odm_setup.sh
@@ -54,6 +54,9 @@ function safe_mkdir() {
     fi
 }
 
+# Set path where local files adjacent to odm_setup.sh can be sourced
+ODM_FILES_DIR="$(dirname "$0")"
+
 SPOTCONF="/etc/spot.conf"
 DSOURCES=('odm')
 DFOLDERS=(
@@ -172,23 +175,23 @@ do
 
         if [ "$format" == "pqt" ] ; then
             log "Creating ODM Impala Parquet table ${f}..."
-            log "${impala_db_shell} --var=ODM_DBNAME=${DBNAME} --var=ODM_TABLENAME=${f} --var=ODM_LOCATION=${HUSER}/${d}/${f} -c -f create_${f}_pqt.sql"
+            log "${impala_db_shell} --var=ODM_DBNAME=${DBNAME} --var=ODM_TABLENAME=${f} --var=ODM_LOCATION=${HUSER}/${d}/${f} -c -f ${ODM_FILES_DIR}/create_${f}_pqt.sql"
 
-            ${impala_db_shell} --var=ODM_DBNAME=${DBNAME} --var=ODM_TABLENAME=${f} --var=ODM_LOCATION=${HUSER}/${d}/${f} -c -f create_${f}_pqt.sql
+            ${impala_db_shell} --var=ODM_DBNAME=${DBNAME} --var=ODM_TABLENAME=${f} --var=ODM_LOCATION=${HUSER}/${d}/${f} -c -f ${ODM_FILES_DIR}/create_${f}_pqt.sql
         fi
 
         # If desired storage format is avro, create ODM as Avro tables with Avro schemas
 
         if [ "$format" == "avro" ] ; then
             log "Adding ${f} Avro schema to ${HUSER}/$d/schema ..."
-            log "${user_hdfs_cmd} dfs -put -f $f.avsc ${HUSER}/$d/schema/$f.avsc"
+            log "${user_hdfs_cmd} dfs -put -f ${ODM_FILES_DIR}/$f.avsc ${HUSER}/$d/schema/$f.avsc"
             
-            ${user_hdfs_cmd} dfs -put -f $f.avsc ${HUSER}/$d/schema/$f.avsc
+            ${user_hdfs_cmd} dfs -put -f ${ODM_FILES_DIR}/$f.avsc ${HUSER}/$d/schema/$f.avsc
         
             log "Creating ODM Impala Avro table ${f}..."
-            log "${impala_db_shell} --var=ODM_DBNAME=${DBNAME} --var=ODM_TABLENAME=${f} --var=ODM_LOCATION=${HUSER}/${d}/${f} --var=ODM_AVRO_URL=hdfs://${HUSER}/${d}/schema/${f}.avsc -c -f create_${f}_avro.sql"
+            log "${impala_db_shell} --var=ODM_DBNAME=${DBNAME} --var=ODM_TABLENAME=${f} --var=ODM_LOCATION=${HUSER}/${d}/${f} --var=ODM_AVRO_URL=hdfs://${HUSER}/${d}/schema/${f}.avsc -c -f ${ODM_FILES_DIR}/create_${f}_avro.sql"
         
-            ${impala_db_shell} --var=ODM_DBNAME=${DBNAME} --var=ODM_TABLENAME=${f} --var=ODM_LOCATION=${HUSER}/${d}/${f} --var=ODM_AVRO_URL=hdfs://${HUSER}/${d}/schema/${f}.avsc -c -f create_${f}_avro.sql
+            ${impala_db_shell} --var=ODM_DBNAME=${DBNAME} --var=ODM_TABLENAME=${f} --var=ODM_LOCATION=${HUSER}/${d}/${f} --var=ODM_AVRO_URL=hdfs://${HUSER}/${d}/schema/${f}.avsc -c -f ${ODM_FILES_DIR}/create_${f}_avro.sql
         fi
 	done
 done

--- a/spot-setup/odm/odm_setup.sh
+++ b/spot-setup/odm/odm_setup.sh
@@ -20,7 +20,15 @@
 # Instructions
 #   To execute this script, run ./odm_setup with a format type (pqt, avro) as an argument.
 #
-#   i.e. ./odm_setup pqt
+#   i.e. ./odm_setup -f pqt
+#
+#   Required Arguments:
+#       -f : desired storage format for ODM tables
+#
+#   Optional Arguments:
+#       --no-sudo : run hdfs commands without sudo
+#       -c : provide custom path to spot.conf
+#
 #   
 #   NOTE: At this time only Parquet and Avro storage formats are supported for the ODM tables.
 
@@ -29,7 +37,7 @@ set -e
 
 function log() {
     # General logger for the ODM setup script that prints any input provided to it
-    printf "hdfs_setup.sh:\n $1\n"
+    printf "odm_setup.sh:\n $1\n"
 }
 
 function safe_mkdir() {

--- a/spot-setup/odm/odm_setup.sh
+++ b/spot-setup/odm/odm_setup.sh
@@ -100,7 +100,9 @@ source $SPOTCONF
 # Check no-sudo argument and set the proper hdfs command to run our create table statements later
 if [[ ${no_sudo} == "true" ]]; then
     hdfs_cmd="hdfs"
+    user_hdfs_cmd="hdfs"
 
+    # If HADOOP_USER_NAME already set, don't attempt to set as hdfs
     if [[ ! -z "${HADOOP_USER_NAME}" ]]; then
         log "HADOOP_USER_NAME: ${HADOOP_USER_NAME}"
     else
@@ -109,6 +111,7 @@ if [[ ${no_sudo} == "true" ]]; then
     fi
 else
     hdfs_cmd="sudo -u hdfs hdfs"
+    user_hdfs_cmd="sudo -u ${USER} hdfs"
 fi
 
 # Creating HDFS user's folder
@@ -178,9 +181,9 @@ do
 
         if [ "$format" == "avro" ] ; then
             log "Adding ${f} Avro schema to ${HUSER}/$d/schema ..."
-            log "${hdfs_cmd} dfs -put -f $f.avsc ${HUSER}/$d/schema/$f.avsc"
+            log "${user_hdfs_cmd} dfs -put -f $f.avsc ${HUSER}/$d/schema/$f.avsc"
             
-            ${hdfs_cmd} dfs -put -f $f.avsc ${HUSER}/$d/schema/$f.avsc
+            ${user_hdfs_cmd} dfs -put -f $f.avsc ${HUSER}/$d/schema/$f.avsc
         
             log "Creating ODM Impala Avro table ${f}..."
             log "${impala_db_shell} --var=ODM_DBNAME=${DBNAME} --var=ODM_TABLENAME=${f} --var=ODM_LOCATION=${HUSER}/${d}/${f} --var=ODM_AVRO_URL=hdfs://${HUSER}/${d}/schema/${f}.avsc -c -f create_${f}_avro.sql"

--- a/spot-setup/odm/odm_setup.sh
+++ b/spot-setup/odm/odm_setup.sh
@@ -157,7 +157,7 @@ fi
 # Creating Spot Database
 
 log "CREATE DATABASE IF NOT EXISTS ${DBNAME};"
-${impala_db_shell} "CREATE DATABASE IF NOT EXISTS ${DBNAME}";
+${impala_db_shell} -q "CREATE DATABASE IF NOT EXISTS ${DBNAME}";
 
 # Creating ODM Impala tables
 

--- a/spot-setup/spot.conf
+++ b/spot-setup/spot.conf
@@ -15,13 +15,12 @@
 # limitations under the License.
 
 
-#node configuration
+# Spot node configuration
 UINODE='node03'
 MLNODE='node04'
 GWNODE='node16'
-DBNAME='spot'
 
-#hdfs - base user and data source config
+# hdfs - base user and data source config
 HUSER='/user/spot'
 NAME_NODE=''
 WEB_PORT=50070
@@ -30,21 +29,38 @@ PROXY_PATH=${HUSER}/${DSOURCE}/hive/y=${YR}/m=${MH}/d=${DY}/
 FLOW_PATH=${HUSER}/${DSOURCE}/hive/y=${YR}/m=${MH}/d=${DY}/
 HPATH=${HUSER}/${DSOURCE}/scored_results/${FDATE}
 
-FLOW_TABLE=flow_view
-DNS_TABLE=dns_view
-PROXY_TABLE=proxy_view
+# Database config
+DBNAME='spot'
+DBENGINE=""
 
-#impala config
+# Impala config
 IMPALA_DEM=node04
 IMPALA_PORT=21050
 
-#local fs base user and data source config
+# Kerberos config
+KERBEROS='false'
+KINIT=/usr/bin/kinit
+PRINCIPAL='user'
+KEYTAB='/opt/security/user.keytab'
+SASL_MECH='GSSAPI'
+SECURITY_PROTO='sasl_plaintext'
+KAFKA_SERVICE_NAME=''
+
+# SSL config
+SSL='false'
+SSL_VERIFY='true'
+CA_LOCATION=''
+CERT=''
+KEY=''
+
+# Local fs base user and data source config
 LUSER='/home/spot'
 LPATH=${LUSER}/ml/${DSOURCE}/${FDATE}
 RPATH=${LUSER}/ipython/user/${FDATE}
 LIPATH=${LUSER}/ingest
 
-#dns suspicious connects config
+# DNS suspicious connects config
+
 USER_DOMAIN=''
 
 SPK_EXEC=''


### PR DESCRIPTION
- This PR is a combination of cherry picks from #134 
- Update odm_setup.sh to include arguments for sudo-less execution (--no-sudo), custom paths for spot.conf (-c), and updated the format argument to specified using the "-f" flag.
- odm_setup.sh now more gracefully handles errors and hdfs directory creation.
- Improved logging
- Updated spot.conf to include Kerberos and SSL configurations