### PR TITLE
[SPOT-277] Updates to Spot Website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/2016/03/index.html
+++ b/2016/03/index.html
@@ -219,7 +219,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/2016/03/index.html
+++ b/2016/03/index.html
@@ -219,7 +219,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/2016/03/index.html
+++ b/2016/03/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/2016/03/index.html
+++ b/2016/03/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/2016/08/index.html
+++ b/2016/08/index.html
@@ -250,7 +250,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/2016/08/index.html
+++ b/2016/08/index.html
@@ -250,7 +250,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/2016/08/index.html
+++ b/2016/08/index.html
@@ -88,7 +88,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/2016/08/index.html
+++ b/2016/08/index.html
@@ -95,7 +95,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/2016/09/index.html
+++ b/2016/09/index.html
@@ -216,7 +216,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/2016/09/index.html
+++ b/2016/09/index.html
@@ -216,7 +216,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/2016/09/index.html
+++ b/2016/09/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/2016/09/index.html
+++ b/2016/09/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/2016/10/index.html
+++ b/2016/10/index.html
@@ -218,7 +218,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/2016/10/index.html
+++ b/2016/10/index.html
@@ -218,7 +218,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/2016/10/index.html
+++ b/2016/10/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/2016/10/index.html
+++ b/2016/10/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/2017/03/index.html
+++ b/2017/03/index.html
@@ -217,7 +217,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/2017/03/index.html
+++ b/2017/03/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/2017/03/index.html
+++ b/2017/03/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/2017/03/index.html
+++ b/2017/03/index.html
@@ -217,7 +217,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,126 @@
+# **Apache Spot (Incubating)**   
+
+Apache Spot is open source software for leveraging insights from flow and packet analysis. It helps enterprises and service providers gain insight on their computing environments through transparency of service delivery and identification of potential security threats or attacks happening among resources operating at cloud scale.
+
+While current threat intelligence tools help, identifying unknown threats and attacks remains a challenge. Apache Spot provides tools to accelerate companies’ ability to expose suspicious connections and previously unseen attacks using flow and packet analysis technologies. 
+<br><br>
+
+----
+
+## **Overview**
+
+With the arrival of big data platforms, security organizations can now make data-driven decisions about how they protect their assets.  Records of network traffic, captured as network flows, are often stored and analyzed for use in network management.  An organization can use this same information to gain insight into what channels corporate information flows through. 
+
+By taking into account additional context such as prevalent attacks and key protocols to the organization, the security team can develop a strategy that applies the right amount of per-channel risk mitigation based on the value of the data flowing through it.  For an organization, we call this “the port perspective”. 
+
+There are two vectors that all organizations should evaluate:
+
+ * A “wide enough, deep enough” protection strategy that involves both edge prevention and sophisticated detection of unusual behavior
+
+ * A deep inspection of key protocols using methods that can scale to the volume of data flowing across that channel
+
+While inspecting specific, unique flows of data that may be important for individual organizations, all organizations can realize significant risk reduction from analysis of network flows and DNS (domain name service) replies.
+
+**Apache Spot**  by leveraging strong technology in both Big Data and Scientific Computing disciplines is a solution intended to support this strategy by focusing on “hard security problems” detecting events such as lateral movement, side-channel data escapes, insider issues, or stealthy behavior in general.  
+
+ 
+### **Telemetry**
+* Flows.
+* DNS (pcaps).
+* Proxy.
+
+### **Parallel Ingest Framework**
+* Open source decoders.
+* Load data in Hadoop.
+* Data transformation.
+
+
+### **Machine Learning**
+* Filter billion of events to a few thousands.
+* Unsupervised learning.
+
+### **Operational Analytics**
+* Visualization.
+* Attack heuristics.
+* Noise filter.
+
+## Try the Apache Spot UI with example data:
+
+*Running Demo on Docker*
+
+1. [Install Docker](https://docs.docker.com/engine/installation/) for your platform 
+2. Run the container: `docker run -it -p 8889:8889 apachespot/spot-demo`
+3. visit [http://localhost:8889/files/ui/flow/suspicious.html#date=2016-07-08](http://localhost:8889/files/ui/proxy/suspicious.html#date=2016-07-08) in your browser to get started
+
+For the full instructions visit the [spot](https://hub.docker.com/r/apachespot/spot-demo/) on Docker hub
+
+## **Getting Started**
+
+Apache Spot can be installed by following our installation manual. To get started, [check out the installation instructions in the documentation](http://spot.incubator.apache.org/doc/).
+
+## **Documentation (Developer Guide)**
+
+Apache Spot functionality is divided into different modules, go to each module for developer documentation:
+
+* [spot-ingest](spot-ingest/README.md)
+* [spot-ml](spot-ml/README.md)
+* [spot-oa](spot-oa/README.md)
+* [spot-setup](spot-setup/README.md)
+
+## **Community Support**
+
+Our Central repository for our Apache Spot solution is found here. If you find a bug, have question or something to discuss please contact us:
+
+* [Create an Issue](https://issues.apache.org/jira/browse/SPOT-20?jql=project%20%3D%20SPOT). 
+* Sign up for the developer mailing list at <dev-subscribe@spot.incubator.apache.org>.
+
+## **Contributing to Apache Spot**
+
+Help us improve Apache Spot!
+
+Apache Spot is Apache 2.0 licensed and accepts contributions via GitHub pull requests. Please follow the next steps
+and join our community.
+
+### **Contributing to Apache Spot code**
+
+* Fork the repo of the module that you wish to commit to.
+* Create a Branch, we use [topic branches](https://git-scm.com/book/en/v2/Git-Branching-Branching-Workflows#Topic-Branches) for our commits. 
+* Push your commit(s) to your repository.
+* Create a pull request to the original repo in Apache Spot organization.
+
+### **Commit Guidelines**
+
+* Bug fixes should be a single commit.
+* Please be clear with the commit messages about what you are fixing or adding to the code base. If you code is addressing an open issue please add the reference to the issue in the comments with: Fix: Issue's URL. 
+
+
+### **Merge approval**
+
+Apache Spot maintainers use +1 in a comment on the code review to indicate acceptance, 
+at least 3 "+1" from maintainers are required to approve the merge. If you have any question or concern please feel free to add a comment in your pull request or branch and tag any of the maintainers.
+
+
+## **Licensing**
+
+Apache Spot is licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for the full license text.
+
+* spot-nfdump [License](https://github.com/Open-Network-Insight/spot-nfdump/blob/master/BSD-license.txt)
+
+## **Maintainers**
+
+<table border="0" cellspacing="0" cellpadding="0">
+        <tr>
+                <td width="125"><a href="https://github.com/EverLoSa"><sub>@EverLoSa</sub><img src="https://avatars.githubusercontent.com/EverLosa" alt="@EverLoSa"></a></td>
+                <td width="125"><a href="https://github.com/ledalima"><sub>@ledalima</sub><img src="https://avatars.githubusercontent.com/ledalima" alt="@ledalima"></a></td>
+                <td width="125"><a href="https://github.com/rabarona "><sub>@rabarona</sub><img src="https://avatars.githubusercontent.com/rabarona " alt="@rabarona"></a></td>
+                <td width="125"><a href="https://github.com/daortizh "><sub>@daortizh</sub><img src="https://avatars.githubusercontent.com/daortizh " alt="@daortizh"></a></td>   	
+        </tr>
+        <tr> 
+                <td width="125"><a href="https://github.com/natedogs911 "><sub>@natedogs911</sub><img src="https://avatars.githubusercontent.com/natedogs911" alt="@natedogs911"></a></td>
+                <td width="125"><a href="https://github.com/NathanSegerlind "><sub>@NathanSegerlind </sub><img src="https://avatars.githubusercontent.com/NathanSegerlind " alt="@NathanSegerlind"></a></td>
+                <td width="125"><a href="https://github.com/moy8011"><sub>@moy8011</sub><img src="https://avatars.githubusercontent.com/moy8011" alt="@moy8011"></a></td>
+        </tr>
+</table>
+
+
+## Thanks

--- a/_Tools/page-massedit.py
+++ b/_Tools/page-massedit.py
@@ -1,0 +1,78 @@
+import os
+import fnmatch
+import massedit
+import re
+
+
+print('Welcome to the regex page editor')
+print('Use this to make changes across all the Spot pages (mainly menus) fast')
+print('This is a result of laziness; enjoy')
+
+
+def FindFiles(_rootDir, pattern: str):
+    _fileList = []
+
+    for root, dirs, files in os.walk(_rootDir):
+        for file in fnmatch.filter(files, pattern):
+            _fileList.append(root + "\\" + file)
+
+    return _fileList
+
+
+def RegSearch(_searchPattern, files):
+    filteredFiles = []
+
+    for filePath in files:
+        with open(filePath, "r", encoding='utf-8') as file:
+            for line in file:
+                pattern = re.compile(_searchPattern)
+                matches = pattern.findall(line)
+                if len(matches) > 0:
+                    print("{} in file {}".format(line, filePath))
+                    filteredFiles.append(filePath)
+                    break
+
+    print("\n{} files found containing {} \n\n".format(len(filteredFiles), _searchPattern))
+    return filteredFiles
+
+
+def RegDelLines(_searchPattern, files):
+    for filePath in files:
+        baseName = os.path.basename(filePath)
+        newFileName = os.path.dirname(filePath) + "\\" + baseName + ".new"
+
+        with open(filePath, "r", encoding='utf-8') as oldFile:
+            # create swap file
+            with open(newFileName, "w", encoding='utf-8') as newFile:
+                for line in oldFile:
+                    pattern = re.compile(_searchPattern)
+                    matches = pattern.findall(line)
+                    if len(matches) == 0:
+                        newFile.write(line)
+                    else:
+                        print("skip")
+
+        # Swap Files
+        os.rename(filePath, filePath + ".old")
+        os.rename(newFileName, filePath)
+        os.remove(filePath + ".old")
+
+
+rootDir = "c:\\code\\incubator-spot"  #input('enter directory:')
+
+files = FindFiles(rootDir, 'index.html')
+
+searchPattern = "slack|SLACK|Slack" #input("Search Pattern:")
+
+files = RegSearch(searchPattern, files)
+
+print("commands(DelLines / ...)")
+cmd = input("How to Proceed?: ")
+
+if cmd.lower() == 'dellines':
+    RegDelLines(searchPattern, files)
+elif cmd == 'regex':
+    print("Not Implemented Yet")
+    #massedit.edit_files(files, ["re.sub()"])
+
+print('Done')

--- a/_Tools/page-massedit.py
+++ b/_Tools/page-massedit.py
@@ -9,6 +9,13 @@ print('Use this to make changes across all the Spot pages fast (mainly menus)')
 print('This is a result of laziness; enjoy \n')
 
 
+def GetRootDir(rootName):
+    filePath = os.path.realpath(__file__)
+    pathSplit = filePath.split('\\')
+    idx = 1 + [i for i, s in enumerate(pathSplit) if rootName in s][-1]
+    return '\\'.join(pathSplit[0:idx])
+
+
 def FindFiles(_rootDir, _pattern: str):
     _fileList = []
 
@@ -47,6 +54,7 @@ def RegDelLines(_searchPattern, _files):
                 for line in oldFile:
                     pattern = re.compile(_searchPattern)
                     matches = pattern.findall(line)
+
                     if len(matches) == 0:
                         newFile.write(line)
                     else:
@@ -82,7 +90,34 @@ def RegInsertAfter(_searchPattern, _files, _line2Insert, _insertType):
         os.remove(filePath + ".old")
 
 
-rootDir = "c:\\code\\incubator-spot"  #input('enter directory:')
+def RegSubstitute(_searchPattern, _files, _text2Sub):
+    for filePath in _files:
+        baseName = os.path.basename(filePath)
+        newFileName = os.path.dirname(filePath) + "\\" + baseName + ".new"
+
+        with open(filePath, "r", encoding='utf-8') as oldFile:
+            # create swap file
+            with open(newFileName, "w", encoding='utf-8') as newFile:
+                for line in oldFile:
+                    pattern = re.compile(_searchPattern)
+                    matches = pattern.findall(line)
+
+                    if len(matches) > 0:
+                        for match in matches:
+                            newLine = line.replace(match, _text2Sub)
+
+                        newFile.write(newLine)
+                    else:
+                        newFile.write(line)
+
+
+        # Swap Files
+        os.rename(filePath, filePath + ".old")
+        os.rename(newFileName, filePath)
+        os.remove(filePath + ".old")
+
+
+rootDir = GetRootDir('incubator-spot')
 
 files = FindFiles(rootDir, 'index.html')
 
@@ -90,7 +125,7 @@ searchPattern = input("Search Pattern:")
 
 files = RegSearch(searchPattern, files)
 
-print("commands(DelLines / InsertAfter/ ...)")
+print("commands(DelLines / InsertAfter/ Sub)")
 
 while True:
     cmd = input("How to Proceed?: ")
@@ -101,7 +136,7 @@ while True:
 
     # Insert After
     elif cmd.lower() == 'insertafter':
-        insertType = input('append (app) or next line (nl)')
+        insertType = input('append (app) or next line (nl):')
 
         # normalise
         if insertType in ['app', 'append']:
@@ -115,13 +150,18 @@ while True:
         else:
             print("Invalid Insertion Type")
 
+    # Substitute
+    elif cmd.lower() == 'sub':
+        subText = input('Text to substitute with:')
+        RegSubstitute(searchPattern, files, subText)
+
     # Regex Replace
-    elif cmd == 'regex':
+    elif cmd.lower() == 'regex':
         print("Not Implemented Yet")
         #massedit.edit_files(files, ["re.sub()"])
 
     # Quit
-    elif cmd in ['q', 'quit']:
+    elif cmd in ['q', 'quit', 'exit']:
         break
 
     # ?!?

--- a/_Tools/page-massedit.py
+++ b/_Tools/page-massedit.py
@@ -4,25 +4,25 @@ import massedit
 import re
 
 
-print('Welcome to the regex page editor')
-print('Use this to make changes across all the Spot pages (mainly menus) fast')
-print('This is a result of laziness; enjoy')
+print('\nWelcome to the regex page editor')
+print('Use this to make changes across all the Spot pages fast (mainly menus)')
+print('This is a result of laziness; enjoy \n')
 
 
-def FindFiles(_rootDir, pattern: str):
+def FindFiles(_rootDir, _pattern: str):
     _fileList = []
 
     for root, dirs, files in os.walk(_rootDir):
-        for file in fnmatch.filter(files, pattern):
+        for file in fnmatch.filter(files, _pattern):
             _fileList.append(root + "\\" + file)
 
     return _fileList
 
 
-def RegSearch(_searchPattern, files):
+def RegSearch(_searchPattern, _files):
     filteredFiles = []
 
-    for filePath in files:
+    for filePath in _files:
         with open(filePath, "r", encoding='utf-8') as file:
             for line in file:
                 pattern = re.compile(_searchPattern)
@@ -36,8 +36,8 @@ def RegSearch(_searchPattern, files):
     return filteredFiles
 
 
-def RegDelLines(_searchPattern, files):
-    for filePath in files:
+def RegDelLines(_searchPattern, _files):
+    for filePath in _files:
         baseName = os.path.basename(filePath)
         newFileName = os.path.dirname(filePath) + "\\" + baseName + ".new"
 
@@ -58,21 +58,74 @@ def RegDelLines(_searchPattern, files):
         os.remove(filePath + ".old")
 
 
+def RegInsertAfter(_searchPattern, _files, _line2Insert, _insertType):
+    for filePath in _files:
+        baseName = os.path.basename(filePath)
+        newFileName = os.path.dirname(filePath) + "\\" + baseName + ".new"
+
+        with open(filePath, "r", encoding='utf-8') as oldFile:
+            # create swap file
+            with open(newFileName, "w", encoding='utf-8') as newFile:
+                for line in oldFile:
+                    pattern = re.compile(_searchPattern)
+                    matches = pattern.findall(line)
+
+                    newFile.write(line)
+
+                    if len(matches) > 0:
+                        newFile.write(_line2Insert)
+
+
+        # Swap Files
+        os.rename(filePath, filePath + ".old")
+        os.rename(newFileName, filePath)
+        os.remove(filePath + ".old")
+
+
 rootDir = "c:\\code\\incubator-spot"  #input('enter directory:')
 
 files = FindFiles(rootDir, 'index.html')
 
-searchPattern = "slack|SLACK|Slack" #input("Search Pattern:")
+searchPattern = input("Search Pattern:")
 
 files = RegSearch(searchPattern, files)
 
-print("commands(DelLines / ...)")
-cmd = input("How to Proceed?: ")
+print("commands(DelLines / InsertAfter/ ...)")
 
-if cmd.lower() == 'dellines':
-    RegDelLines(searchPattern, files)
-elif cmd == 'regex':
-    print("Not Implemented Yet")
-    #massedit.edit_files(files, ["re.sub()"])
+while True:
+    cmd = input("How to Proceed?: ")
 
-print('Done')
+    # Delete Lines
+    if cmd.lower() == 'dellines':
+        RegDelLines(searchPattern, files)
+
+    # Insert After
+    elif cmd.lower() == 'insertafter':
+        insertType = input('append (app) or next line (nl)')
+
+        # normalise
+        if insertType in ['app', 'append']:
+            insertType = 'a'
+        elif insertType in ['next line', 'nl']:
+            insertType = 'n'
+
+        if insertType in ['a', 'n']:
+            line2Insert = input("What to insert: ")
+            RegInsertAfter(searchPattern, files, line2Insert, insertType)
+        else:
+            print("Invalid Insertion Type")
+
+    # Regex Replace
+    elif cmd == 'regex':
+        print("Not Implemented Yet")
+        #massedit.edit_files(files, ["re.sub()"])
+
+    # Quit
+    elif cmd in ['q', 'quit']:
+        break
+
+    # ?!?
+    else:
+        print("Invalid Command")
+
+print('Bye')

--- a/apache-spot-3-most-asked-questions/index.html
+++ b/apache-spot-3-most-asked-questions/index.html
@@ -294,7 +294,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/apache-spot-3-most-asked-questions/index.html
+++ b/apache-spot-3-most-asked-questions/index.html
@@ -294,7 +294,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/apache-spot-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
+++ b/apache-spot-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
@@ -299,7 +299,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/apache-spot-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
+++ b/apache-spot-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
@@ -299,7 +299,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/apache-spot-3-most-asked-questions/index.html
+++ b/blog/apache-spot-3-most-asked-questions/index.html
@@ -253,7 +253,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/apache-spot-3-most-asked-questions/index.html
+++ b/blog/apache-spot-3-most-asked-questions/index.html
@@ -253,7 +253,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/apache-spot-3-most-asked-questions/index.html
+++ b/blog/apache-spot-3-most-asked-questions/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/blog/apache-spot-3-most-asked-questions/index.html
+++ b/blog/apache-spot-3-most-asked-questions/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/blog/apache-spot-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
+++ b/blog/apache-spot-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
@@ -258,7 +258,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/apache-spot-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
+++ b/blog/apache-spot-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/blog/apache-spot-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
+++ b/blog/apache-spot-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/blog/apache-spot-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
+++ b/blog/apache-spot-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
@@ -258,7 +258,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/apache-spot-product-architecture-overview/index.html
+++ b/blog/apache-spot-product-architecture-overview/index.html
@@ -247,7 +247,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/apache-spot-product-architecture-overview/index.html
+++ b/blog/apache-spot-product-architecture-overview/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/blog/apache-spot-product-architecture-overview/index.html
+++ b/blog/apache-spot-product-architecture-overview/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/blog/apache-spot-product-architecture-overview/index.html
+++ b/blog/apache-spot-product-architecture-overview/index.html
@@ -247,7 +247,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/how-apache-spot-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
+++ b/blog/how-apache-spot-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
@@ -240,7 +240,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/how-apache-spot-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
+++ b/blog/how-apache-spot-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
@@ -240,7 +240,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/how-apache-spot-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
+++ b/blog/how-apache-spot-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/blog/how-apache-spot-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
+++ b/blog/how-apache-spot-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/blog/index.html
+++ b/blog/index.html
@@ -338,7 +338,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/index.html
+++ b/blog/index.html
@@ -338,7 +338,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/index.html
+++ b/blog/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/blog/index.html
+++ b/blog/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../community/committers">Project Committers</a></li>
                                 	<li><a href="../community/contribute">How to Contribute</a></li>

--- a/blog/jupyter-notebooks-for-data-analysis/index.html
+++ b/blog/jupyter-notebooks-for-data-analysis/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/blog/jupyter-notebooks-for-data-analysis/index.html
+++ b/blog/jupyter-notebooks-for-data-analysis/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/blog/jupyter-notebooks-for-data-analysis/index.html
+++ b/blog/jupyter-notebooks-for-data-analysis/index.html
@@ -288,7 +288,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/jupyter-notebooks-for-data-analysis/index.html
+++ b/blog/jupyter-notebooks-for-data-analysis/index.html
@@ -288,7 +288,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/strength-in-numbers-why-consider-open-source-cybersecurity-analytics/index.html
+++ b/blog/strength-in-numbers-why-consider-open-source-cybersecurity-analytics/index.html
@@ -229,7 +229,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/strength-in-numbers-why-consider-open-source-cybersecurity-analytics/index.html
+++ b/blog/strength-in-numbers-why-consider-open-source-cybersecurity-analytics/index.html
@@ -229,7 +229,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/strength-in-numbers-why-consider-open-source-cybersecurity-analytics/index.html
+++ b/blog/strength-in-numbers-why-consider-open-source-cybersecurity-analytics/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/blog/strength-in-numbers-why-consider-open-source-cybersecurity-analytics/index.html
+++ b/blog/strength-in-numbers-why-consider-open-source-cybersecurity-analytics/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/category/cybersecurity/index.html
+++ b/category/cybersecurity/index.html
@@ -218,7 +218,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/category/cybersecurity/index.html
+++ b/category/cybersecurity/index.html
@@ -218,7 +218,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/category/cybersecurity/index.html
+++ b/category/cybersecurity/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/category/cybersecurity/index.html
+++ b/category/cybersecurity/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/category/data-science/index.html
+++ b/category/data-science/index.html
@@ -219,7 +219,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/category/data-science/index.html
+++ b/category/data-science/index.html
@@ -219,7 +219,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/category/data-science/index.html
+++ b/category/data-science/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/category/data-science/index.html
+++ b/category/data-science/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/category/ipython-notebooks/index.html
+++ b/category/ipython-notebooks/index.html
@@ -218,7 +218,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/category/ipython-notebooks/index.html
+++ b/category/ipython-notebooks/index.html
@@ -218,7 +218,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/category/ipython-notebooks/index.html
+++ b/category/ipython-notebooks/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/category/ipython-notebooks/index.html
+++ b/category/ipython-notebooks/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/category/security-analytics/index.html
+++ b/category/security-analytics/index.html
@@ -218,7 +218,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/category/security-analytics/index.html
+++ b/category/security-analytics/index.html
@@ -218,7 +218,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/category/security-analytics/index.html
+++ b/category/security-analytics/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/category/security-analytics/index.html
+++ b/category/security-analytics/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/category/threat-analysis-tools/index.html
+++ b/category/threat-analysis-tools/index.html
@@ -218,7 +218,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/category/threat-analysis-tools/index.html
+++ b/category/threat-analysis-tools/index.html
@@ -218,7 +218,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/category/threat-analysis-tools/index.html
+++ b/category/threat-analysis-tools/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/category/threat-analysis-tools/index.html
+++ b/category/threat-analysis-tools/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/category/uncategorized/index.html
+++ b/category/uncategorized/index.html
@@ -271,7 +271,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/category/uncategorized/index.html
+++ b/category/uncategorized/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/category/uncategorized/index.html
+++ b/category/uncategorized/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/category/uncategorized/index.html
+++ b/category/uncategorized/index.html
@@ -271,7 +271,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/community/committers/index.html
+++ b/community/committers/index.html
@@ -348,7 +348,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/community/committers/index.html
+++ b/community/committers/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li class="active"><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/community/committers/index.html
+++ b/community/committers/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/community/committers/index.html
+++ b/community/committers/index.html
@@ -348,7 +348,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/community/contribute/index.html
+++ b/community/contribute/index.html
@@ -275,7 +275,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/community/contribute/index.html
+++ b/community/contribute/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li class="active"><a href="../../community/contribute">How to Contribute</a></li>

--- a/community/contribute/index.html
+++ b/community/contribute/index.html
@@ -275,7 +275,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/community/contribute/index.html
+++ b/community/contribute/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/community/index.html
+++ b/community/index.html
@@ -5,197 +5,243 @@
 <!--[if (IE 8)&!(IEMobile)]><html lang="en-US" class="no-js lt-ie9"><![endif]-->
 <!--[if gt IE 8]><!-->
 <html lang="en-US" class="no-js">
-    <!--<![endif]-->
+<!--<![endif]-->
 
-    <head>
-        <meta charset="utf-8">
+<head>
+    <meta charset="utf-8">
 
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-        <title>Community - Apache Spot</title>
+    <title>Community - Apache Spot</title>
 
-        <meta name="HandheldFriendly" content="True">
-        <meta name="MobileOptimized" content="320">
-        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta name="HandheldFriendly" content="True">
+    <meta name="MobileOptimized" content="320">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-        <link rel="apple-touch-icon" href="../library/images/apple-touch-icon.png">
-        <link rel="icon" href="../favicon.png">
-        <!--[if IE]>
+    <link rel="apple-touch-icon" href="../library/images/apple-touch-icon.png">
+    <link rel="icon" href="../favicon.png">
+    <!--[if IE]>
         <link rel="shortcut icon" href="http://spot.incubator.apache.org/favicon.ico">
         <![endif]-->
-        <meta name="msapplication-TileColor" content="#f01d4f">
-        <meta name="msapplication-TileImage" content="../library/images/win8-tile-icon.png">
-        <meta name="theme-color" content="#121212">
+    <meta name="msapplication-TileColor" content="#f01d4f">
+    <meta name="msapplication-TileImage" content="../library/images/win8-tile-icon.png">
+    <meta name="theme-color" content="#121212">
 
-        <link rel='dns-prefetch' href='//fonts.googleapis.com' />
-        <link rel='dns-prefetch' href='//s.w.org' />
-        <link rel="alternate" type="application/rss+xml" title="Apache Spot &raquo; Feed" href="../feed/" />
+    <link rel='dns-prefetch' href='//fonts.googleapis.com' />
+    <link rel='dns-prefetch' href='//s.w.org' />
+    <link rel="alternate" type="application/rss+xml" title="Apache Spot &raquo; Feed" href="../feed/" />
 
-        <link rel='stylesheet' id='googleFonts-css'  href='http://fonts.googleapis.com/css?family=Lato%3A400%2C700%2C400italic%2C700italic' type='text/css' media='all' />
-        <link rel='stylesheet' id='bones-stylesheet-css'  href='../library/css/style.css' type='text/css' media='all' />
-        <!--[if lt IE 9]>
+    <link rel='stylesheet' id='googleFonts-css' href='http://fonts.googleapis.com/css?family=Lato%3A400%2C700%2C400italic%2C700italic'
+        type='text/css' media='all' />
+    <link rel='stylesheet' id='bones-stylesheet-css' href='../library/css/style.css' type='text/css' media='all' />
+    <!--[if lt IE 9]>
         <link rel='stylesheet' id='bones-ie-only-css'  href='http://spot.incubator.apache.org/library/css/ie.css' type='text/css' media='all' />
         <![endif]-->
-        <link rel='stylesheet' id='mm-css-css'  href='../library/css/meanmenu.css' type='text/css' media='all' />
-        <script type='text/javascript' src='../library/js/libs/modernizr.custom.min.js'></script>
-        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
-        <script type='text/javascript' src='../library/js/jquery-migrate.min.js'></script>
-        <script type='text/javascript' src='../library/js/jquery.meanmenu.js'></script>
+    <link rel='stylesheet' id='mm-css-css' href='../library/css/meanmenu.css' type='text/css' media='all' />
+    <script type='text/javascript' src='../library/js/libs/modernizr.custom.min.js'></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+    <script type='text/javascript' src='../library/js/jquery-migrate.min.js'></script>
+    <script type='text/javascript' src='../library/js/jquery.meanmenu.js'></script>
 
-		<script>
-		  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-		  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-		  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-		  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script>
+        (function (i, s, o, g, r, a, m) {
+        i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+            (i[r].q = i[r].q || []).push(arguments)
+        }, i[r].l = 1 * new Date(); a = s.createElement(o),
+            m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+        })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
 
-		  ga('create', 'UA-87470508-1', 'auto');
-		  ga('send', 'pageview');
+        ga('create', 'UA-87470508-1', 'auto');
+        ga('send', 'pageview');
 
-		</script>
-    </head>
+    </script>
+</head>
 
-    <body class="page">
+<body class="page">
 
-        <div id="container">
-            <header class="header">
+    <div id="container">
+        <header class="header">
 
-                <div id="inner-header" class="wrap cf">
+            <div id="inner-header" class="wrap cf">
 
-                    <p id="logo" class="h1" itemscope itemtype="http://schema.org/Organization">
-                        <a href="http://spot.incubator.apache.org/" rel="nofollow"><img src="../library/images/logo.png" alt="Apache Spot" /></a>
-                    </p>
+                <p id="logo" class="h1" itemscope itemtype="http://schema.org/Organization">
+                    <a href="http://spot.incubator.apache.org/" rel="nofollow">
+                        <img src="../library/images/logo.png" alt="Apache Spot" />
+                    </a>
+                </p>
 
-                    <nav>
-                        <ul id="menu-main-menu" class="nav top-nav cf">
-                          <li id="menu-item-129" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-129">
-                              <a href="../get-started">Get Started</a>
-                              <ul class="sub-menu">
-                                <li><a href="../get-started">Get Started</a></li>
-                                <li><a href="../get-started/supporting-apache">Supporting Apache</a></li>
-                                <li><a href="../get-started/environment">Environment</a></li>
-                                <li><a href="../get-started/architecture">Architecture</a></li>
-                                <li><a href="../get-started/demo">Demo</a></li>
-                              </ul>
-                          </li>
-                            <li id="menu-item-5" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-5">
-                                <a href="../download">Download</a>
-                            </li>
-                            <li id="menu-item-130" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-130 active">
-                                <a href="../community">Community</a>
-                                <ul class="sub-menu com-sm">
-                                	<li class="dropmenu-head">Get in Touch</li>
-                                	<li class="active"><a href="../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
-                                	<li class="divider"></li>
-                                	<li><a href="../community/committers">Project Committers</a></li>
-                                	<li><a href="../community/contribute">How to Contribute</a></li>
-                                	<li class="divider"></li>
-                                	<li class="dropmenu-head">Developer Resources</li>
-                                	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
-                                	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
-                                	<li class="dropmenu-head">Social Media</li>
-                                	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
-                                </ul>
-                            </li>
-                            <li id="menu-item-106" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-106">
-                                <a href="../doc">Documentation</a>
-                            </li>
-                            <li class="menu-item menu-item-has-children">
-                                <a href="#">Project Components</a>
-                                <ul class="sub-menu">
-                                	<li><a href="../project-components/ingestion">Ingestion</a></li>
-                                	<li><a href="../project-components/machine-learning">Machine Learning</a></li>
-                                  <li><a href="../project-components/suspicious-connects-analysis">Suspicous Connects Analysis</a></li>
-                                	<li><a href="../project-components/visualization">Visualization</a></li>
-                                  <li class="under-dev">Under Development</li>
-                                  <li><a href="../project-components/open-data-models">Open Data Models</a></li>
-                                </ul>
-                            </li>
-                            <li id="menu-item-13" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-13">
-                                <a href="../blog">Blog</a>
-                            </li>
-                        </ul>
-                    </nav>
-
-                </div>
-
-            </header>
-
-            <div id="mobile-nav"></div>
-
-            <div id="content">
-
-            	<div class="wrap cf"><!--if page has sidebar, add class "with-sidebar"-->
-            		<div class="main">
-					<h1>Apache Spot Mailing Lists and Chat Rooms</h1>
-					<p>Get help using Spot or contribute to the project on our mailing lists or our chat room:</p>
-
-           <strong>Get Help</strong>
-					<ul>
-            <li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-						<li><a href="mailto:user@spot.apache.org">user@spot.apache.org</a> (<a href="mailto:user-subscribe@spot.incubator.apache.org">subscribe</a>) (<a href="mailto:user-unsubscribe@spot.incubator.apache.org">unsubscribe</a>) (<a href="http://mail-archives.apache.org/mod_mbox/spot-user/" target="_blank">archives</a>) - for usage questions, help, and announcements.</li>
-            <li><a href="mailto:issues@spot.incubator.apache.org">issues@spot.incubator.apache.org</a> (<a href="mailto:issues-subscribe@spot.incubator.apache.org">subscribe</a>) (<a href="mailto:issues-unsubscribe@spot.incubator.apache.org">unsubscribe</a>) (<a href="http://mail-archives.apache.org/mod_mbox/spot-issues/" target="_blank">archives</a>) - receives an email notification for all ticket updates made in the Spot JIRA issue tracker.</li>
-
-					</ul>
-
-					<strong>Developer Mailing Lists</strong>
-					<ul>
-						<li><a href="mailto:dev@spot.incubator.apache.org">dev@spot.incubator.apache.org</a> (<a href="mailto:dev-subscribe@spot.incubator.apache.org">subscribe</a>) (<a href="mailto:dev-unsubscribe@spot.incubator.apache.org">unsubscribe</a>) (<a href="http://mail-archives.apache.org/mod_mbox/spot-dev/" target="_blank">archives</a>) - for people who want to contribute code to Spot.</li>
-
-						<li><a href="mailto:commits@spot.incubator.apache.org">commits@spot.incubator.apache.org</a> (<a href="mailto:commits-subscribe@spot.incubator.apache.org">subscribe</a>) (<a href="mailto:commits-subscribe@spot.incubator.apache.org">unsubscribe</a>) (<a href="http://mail-archives.apache.org/mod_mbox/incubator-spot-commits/" target="_blank">archives</a>) - receives an email notification of all code changes to the Spot Git repository.</li>
-					</ul>
-
-					<strong>Community Resources</strong>
-					<ul>
-						<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">GitHub</a> - where users and committers will find tools and technical information to commit.</li>
-
-            <li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Spot Slack channel</a> - where many Spot developers and users hang out to answer questions and chat.</li>
-					</ul>
-
-            		</div>
-
-            	</div>
+                <nav>
+                    <ul id="menu-main-menu" class="nav top-nav cf">
+                        <li id="menu-item-129" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-129">
+                            <a href="../get-started">Get Started</a>
+                            <ul class="sub-menu">
+                                <li>
+                                    <a href="../get-started">Get Started</a>
+                                </li>
+                                <li>
+                                    <a href="../get-started/supporting-apache">Supporting Apache</a>
+                                </li>
+                                <li>
+                                    <a href="../get-started/environment">Environment</a>
+                                </li>
+                                <li>
+                                    <a href="../get-started/architecture">Architecture</a>
+                                </li>
+                                <li>
+                                    <a href="../get-started/demo">Demo</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li id="menu-item-5" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-5">
+                            <a href="../download">Download</a>
+                        </li>
+                        <li id="menu-item-130" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-130 active">
+                            <a href="../community">Community</a>
+                            <ul class="sub-menu com-sm">
+                                <li class="dropmenu-head">Get in Touch</li>
+                                <li class="active">
+                                    <a href="../community" class="mail">Mailing Lists</a>
+                                </li>
+                                <li class="divider"></li>
+                                <li>
+                                    <a href="../community/committers">Project Committers</a>
+                                </li>
+                                <li>
+                                    <a href="../community/contribute">How to Contribute</a>
+                                </li>
+                                <li class="divider"></li>
+                                <li class="dropmenu-head">Developer Resources</li>
+                                <li>
+                                    <a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a>
+                                </li>
+                                <li>
+                                    <a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a>
+                                </li>
+                                <li class="divider"></li>
+                                <li class="dropmenu-head">Social Media</li>
+                                <li>
+                                    <a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li id="menu-item-106" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-106">
+                            <a href="../doc">Documentation</a>
+                        </li>
+                        <li class="menu-item menu-item-has-children">
+                            <a href="#">Project Components</a>
+                            <ul class="sub-menu">
+                                <li>
+                                    <a href="../project-components/ingestion">Ingestion</a>
+                                </li>
+                                <li>
+                                    <a href="../project-components/machine-learning">Machine Learning</a>
+                                </li>
+                                <li>
+                                    <a href="../project-components/suspicious-connects-analysis">Suspicous Connects Analysis</a>
+                                </li>
+                                <li>
+                                    <a href="../project-components/visualization">Visualization</a>
+                                </li>
+                                <li class="under-dev">Under Development</li>
+                                <li>
+                                    <a href="../project-components/open-data-models">Open Data Models</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li id="menu-item-13" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-13">
+                            <a href="../blog">Blog</a>
+                        </li>
+                    </ul>
+                </nav>
 
             </div>
 
+        </header>
 
-            <div id="more-info">
-                <div class="wrap cf">
+        <div id="mobile-nav"></div>
 
-                    <p>
-                        <a href="https://github.com/apache/incubator-spot" class="y-btn" target="_blank">More Info</a>
-                    </p>
+        <div id="content">
 
-                    <p style="margin-top:50px;"><img src="../library/images/apache-incubator.png" alt="Apache Incubator" />
-                    </p>
+            <div class="wrap cf">
+                <!--if page has sidebar, add class "with-sidebar"-->
+                <div class="main">
+                    <h1>Apache Spot Mailing Lists and Chat Rooms</h1>
+                    <p>Get help using Spot or contribute to the project on our mailing lists or our chat room:</p>
 
-                    <p class="disclaimer">
-                        Apache Spot is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator. Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects. While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
-                    </p>
+                    <strong>Get Help</strong>
+                    <ul>
+                        <li>
+                            <a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a>
+                        </li>
+                        <li>
+                            <a href="mailto:user@spot.apache.org">user@spot.apache.org</a> (<a href="mailto:user-subscribe@spot.incubator.apache.org">subscribe</a>) (<a href="mailto:user-unsubscribe@spot.incubator.apache.org">unsubscribe</a>) (<a href="http://mail-archives.apache.org/mod_mbox/spot-user/" target="_blank">archives</a>) - for usage questions, help, and announcements.</li>
+                        <li>
+                            <a href="mailto:issues@spot.incubator.apache.org">issues@spot.incubator.apache.org</a> (<a href="mailto:issues-subscribe@spot.incubator.apache.org">subscribe</a>) (<a href="mailto:issues-unsubscribe@spot.incubator.apache.org">unsubscribe</a>) (<a href="http://mail-archives.apache.org/mod_mbox/spot-issues/" target="_blank">archives</a>) - receives an email notification for all ticket updates made in the Spot JIRA issuetracker.</li>
+                    </ul>
 
-                    <p class="disclaimer">
-                        The contents of this website are © 2016 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
-                    </p>
+                    <strong>Developer Mailing Lists</strong>
+                    <ul>
+                        <li>
+                            <a href="mailto:dev@spot.incubator.apache.org">dev@spot.incubator.apache.org</a> (<a href="mailto:dev-subscribe@spot.incubator.apache.org">subscribe</a>) (<a href="mailto:dev-unsubscribe@spot.incubator.apache.org">unsubscribe</a>) (<a href="http://mail-archives.apache.org/mod_mbox/spot-dev/" target="_blank">archives</a>) - for people who want to contribute code to Spot.</li>
+                        <li>
+                            <a href="mailto:commits@spot.incubator.apache.org">commits@spot.incubator.apache.org</a> (<a href="mailto:commits-subscribe@spot.incubator.apache.org">subscribe</a>) (<a href="mailto:commits-subscribe@spot.incubator.apache.org">unsubscribe</a>) (<a href="http://mail-archives.apache.org/mod_mbox/incubator-spot-commits/" target="_blank">archives</a>) - receives an email notification of all code changes to the Spot Git repository.</li>
+                    </ul>
+
+                    <strong>Community Resources</strong>
+                    <ul>
+                        <li>
+                            <a href="https://github.com/apache/incubator-spot" target="_blank" class="github">GitHub</a> - where users and committers will find tools and technical information to commit.</li>
+                    </ul>
+
                 </div>
+
             </div>
-
-            <footer class="footer" role="contentinfo" itemscope itemtype="http://schema.org/WPFooter">
-
-                <div id="inner-footer" class="wrap cf">
-
-                    <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
-                    </p>
-
-                </div>
-
-            </footer>
 
         </div>
-		<a href="#0" class="cd-top">Top</a>
-        <script type='text/javascript' src='../library/js/scripts.js'></script>
 
-    </body>
+
+        <div id="more-info">
+            <div class="wrap cf">
+
+                <p>
+                    <a href="https://github.com/apache/incubator-spot" class="y-btn" target="_blank">More Info</a>
+                </p>
+
+                <p style="margin-top:50px;">
+                    <img src="../library/images/apache-incubator.png" alt="Apache Incubator" />
+                </p>
+
+                <p class="disclaimer">
+                    Apache Spot is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator.
+                    Incubation is required of all newly accepted projects until a further review indicates that the infrastructure,
+                    communications, and decision making process have stabilized in a manner consistent with other successful
+                    ASF projects. While incubation status is not necessarily a reflection of the completeness or stability
+                    of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
+                </p>
+
+                <p class="disclaimer">
+                    The contents of this website are © 2016 Apache Software Foundation under the terms of the Apache License v2. Apache Spot
+                    and its logo are trademarks of the Apache Software Foundation.
+                </p>
+            </div>
+        </div>
+
+        <footer class="footer" role="contentinfo" itemscope itemtype="http://schema.org/WPFooter">
+
+            <div id="inner-footer" class="wrap cf">
+
+                <p class="source-org copyright" style="text-align:center;">
+                    &copy; 2016 Apache Spot.
+                </p>
+
+            </div>
+
+        </footer>
+
+    </div>
+    <a href="#0" class="cd-top">Top</a>
+    <script type='text/javascript' src='../library/js/scripts.js'></script>
+
+</body>
 
 </html>

--- a/community/index.html
+++ b/community/index.html
@@ -230,7 +230,7 @@
             <div id="inner-footer" class="wrap cf">
 
                 <p class="source-org copyright" style="text-align:center;">
-                    &copy; 2016 Apache Spot.
+                    &copy; 2018 Apache Spot.
                 </p>
 
             </div>

--- a/community/index.html
+++ b/community/index.html
@@ -111,12 +111,9 @@
                                 </li>
                                 <li class="divider"></li>
                                 <li class="dropmenu-head">Developer Resources</li>
-                                <li>
-                                    <a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a>
-                                </li>
-                                <li>
-                                    <a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a>
-                                </li>
+                                <li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
+                                <li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
+                                <li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>
                                 <li class="divider"></li>
                                 <li class="dropmenu-head">Social Media</li>
                                 <li>
@@ -189,8 +186,10 @@
 
                     <strong>Community Resources</strong>
                     <ul>
-                        <li>
-                            <a href="https://github.com/apache/incubator-spot" target="_blank" class="github">GitHub</a> - where users and committers will find tools and technical information to commit.</li>
+                        <li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">GitHub</a> 
+                            - where users and committers will find tools and technical information to commit.</li>
+                        <li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a>
+                            - where deevelopers will find project details such as roadmap, meeting notes, and other useful write-ups</li>
                     </ul>
 
                 </div>

--- a/community/index.html
+++ b/community/index.html
@@ -171,7 +171,7 @@
                             <a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a>
                         </li>
                         <li>
-                            <a href="mailto:user@spot.apache.org">user@spot.apache.org</a> (<a href="mailto:user-subscribe@spot.incubator.apache.org">subscribe</a>) (<a href="mailto:user-unsubscribe@spot.incubator.apache.org">unsubscribe</a>) (<a href="http://mail-archives.apache.org/mod_mbox/spot-user/" target="_blank">archives</a>) - for usage questions, help, and announcements.</li>
+                            <a href="mailto:user@spot.incubator.apache.org">user@spot.incubator.apache.org</a> (<a href="mailto:user-subscribe@spot.incubator.apache.org">subscribe</a>) (<a href="mailto:user-unsubscribe@spot.incubator.apache.org">unsubscribe</a>) (<a href="http://mail-archives.apache.org/mod_mbox/spot-user/" target="_blank">archives</a>) - for usage questions, help, and announcements.</li>
                         <li>
                             <a href="mailto:issues@spot.incubator.apache.org">issues@spot.incubator.apache.org</a> (<a href="mailto:issues-subscribe@spot.incubator.apache.org">subscribe</a>) (<a href="mailto:issues-unsubscribe@spot.incubator.apache.org">unsubscribe</a>) (<a href="http://mail-archives.apache.org/mod_mbox/spot-issues/" target="_blank">archives</a>) - receives an email notification for all ticket updates made in the Spot JIRA issuetracker.</li>
                     </ul>

--- a/community/index.html
+++ b/community/index.html
@@ -230,7 +230,7 @@
             <div id="inner-footer" class="wrap cf">
 
                 <p class="source-org copyright" style="text-align:center;">
-                    &copy; 2018 Apache Spot.
+                    &copy; 2019 Apache Spot.
                 </p>
 
             </div>

--- a/contribute/index.html
+++ b/contribute/index.html
@@ -206,7 +206,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/contribute/index.html
+++ b/contribute/index.html
@@ -206,7 +206,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/contribute/index.html
+++ b/contribute/index.html
@@ -60,7 +60,6 @@
 			<div class="social-sidebar">
 				<a href="mailto:info@apache-spot.io"><span class="icon-envelope"></span></a>
 				<a href="https://twitter.com/ApacheSpot" target="_blank"><span class="icon-twitter"></a>
-				<a href="http://slack.apache-spot.io/" target="_blank"><span class="icon-slack"></span></a>
 			</div>
             <header class="header">
 
@@ -183,7 +182,6 @@
             <div id="more-info">
                 <div class="wrap cf">
                     <p class="social-icons">
-                        <a href="mailto:info@apache-spot.io"><span class="icon-envelope"></span></a><a href="https://twitter.com/ApacheSpot" target="_blank"><span class="icon-twitter"></span><a href="http://slack.apache-spot.io/" target="_blank"><img src="../library/images/add-to-slack.png" alt="" class="add-to-slack" /></a></a>
                     </p>
 
                     <p>

--- a/doc/index.html
+++ b/doc/index.html
@@ -70,7 +70,6 @@
                   <ul class="sub-menu com-sm">
                     <li class="dropmenu-head">Get in Touch</li>
                     <li><a href="../community" class="mail">Mailing Lists</a></li>
-                    <li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                     <li class="divider"></li>
                     <li><a href="../community/committers">Project Committers</a></li>
                     <li><a href="../community/contribute">How to Contribute</a></li>

--- a/doc/index.html
+++ b/doc/index.html
@@ -77,7 +77,7 @@
                     <li class="dropmenu-head">Developer Resources</li>
                     <li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                     <li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                    <li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                    <li class="divider"></li>
                     <li class="dropmenu-head">Social Media</li>
                     <li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                   </ul>

--- a/download/index.html
+++ b/download/index.html
@@ -215,7 +215,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/download/index.html
+++ b/download/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/download/index.html
+++ b/download/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../community/committers">Project Committers</a></li>
                                 	<li><a href="../community/contribute">How to Contribute</a></li>

--- a/download/index.html
+++ b/download/index.html
@@ -215,7 +215,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/get-started/architecture/index.html
+++ b/get-started/architecture/index.html
@@ -164,7 +164,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/get-started/architecture/index.html
+++ b/get-started/architecture/index.html
@@ -164,7 +164,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/get-started/architecture/index.html
+++ b/get-started/architecture/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/get-started/architecture/index.html
+++ b/get-started/architecture/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/get-started/demo/index.html
+++ b/get-started/demo/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/get-started/demo/index.html
+++ b/get-started/demo/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/get-started/demo/index.html
+++ b/get-started/demo/index.html
@@ -167,7 +167,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/get-started/demo/index.html
+++ b/get-started/demo/index.html
@@ -167,7 +167,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/get-started/environment/index.html
+++ b/get-started/environment/index.html
@@ -172,7 +172,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/get-started/environment/index.html
+++ b/get-started/environment/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/get-started/environment/index.html
+++ b/get-started/environment/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/get-started/environment/index.html
+++ b/get-started/environment/index.html
@@ -172,7 +172,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/get-started/index.html
+++ b/get-started/index.html
@@ -210,7 +210,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/get-started/index.html
+++ b/get-started/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/get-started/index.html
+++ b/get-started/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../community/committers">Project Committers</a></li>
                                 	<li><a href="../community/contribute">How to Contribute</a></li>

--- a/get-started/index.html
+++ b/get-started/index.html
@@ -210,7 +210,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/get-started/supporting-apache/index.html
+++ b/get-started/supporting-apache/index.html
@@ -205,7 +205,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/get-started/supporting-apache/index.html
+++ b/get-started/supporting-apache/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/get-started/supporting-apache/index.html
+++ b/get-started/supporting-apache/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/get-started/supporting-apache/index.html
+++ b/get-started/supporting-apache/index.html
@@ -205,7 +205,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/how-apache-spot-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
+++ b/how-apache-spot-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
@@ -275,7 +275,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot (Incubating).
+                        &copy; 2018 Apache Spot (Incubating).
                     </p>
 
                 </div>

--- a/how-apache-spot-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
+++ b/how-apache-spot-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
@@ -275,7 +275,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot (Incubating).
+                        &copy; 2019 Apache Spot (Incubating).
                     </p>
 
                 </div>

--- a/how-open-network-insight-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
+++ b/how-open-network-insight-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
@@ -287,7 +287,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot (Incubating).
+                        &copy; 2019 Apache Spot (Incubating).
                     </p>
 
                 </div>

--- a/how-open-network-insight-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
+++ b/how-open-network-insight-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
@@ -287,7 +287,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot (Incubating).
+                        &copy; 2018 Apache Spot (Incubating).
                     </p>
 
                 </div>

--- a/index.html
+++ b/index.html
@@ -431,7 +431,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/index.html
+++ b/index.html
@@ -90,7 +90,8 @@
                                 	<li class="divider"></li>
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
-                                	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
+                                    <li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                    <li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>
                                 	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>

--- a/index.html
+++ b/index.html
@@ -84,7 +84,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="community/committers">Project Committers</a></li>
                                 	<li><a href="community/contribute">How to Contribute</a></li>

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                     <li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                    <li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>
+									<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>
                                 	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>

--- a/index.html
+++ b/index.html
@@ -431,7 +431,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/jupyter-notebooks-for-data-analysis/index.html
+++ b/jupyter-notebooks-for-data-analysis/index.html
@@ -314,7 +314,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot (Incubating).
+                        &copy; 2019 Apache Spot (Incubating).
                     </p>
 
                 </div>

--- a/jupyter-notebooks-for-data-analysis/index.html
+++ b/jupyter-notebooks-for-data-analysis/index.html
@@ -314,7 +314,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot (Incubating).
+                        &copy; 2018 Apache Spot (Incubating).
                     </p>
 
                 </div>

--- a/open-network-insight-3-most-asked-questions/index.html
+++ b/open-network-insight-3-most-asked-questions/index.html
@@ -300,7 +300,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/open-network-insight-3-most-asked-questions/index.html
+++ b/open-network-insight-3-most-asked-questions/index.html
@@ -300,7 +300,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/open-network-insight-oni-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
+++ b/open-network-insight-oni-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
@@ -305,7 +305,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/open-network-insight-oni-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
+++ b/open-network-insight-oni-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
@@ -305,7 +305,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/project-components/ingestion/index.html
+++ b/project-components/ingestion/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/project-components/ingestion/index.html
+++ b/project-components/ingestion/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/project-components/ingestion/index.html
+++ b/project-components/ingestion/index.html
@@ -204,7 +204,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/project-components/ingestion/index.html
+++ b/project-components/ingestion/index.html
@@ -204,7 +204,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/project-components/machine-learning/index.html
+++ b/project-components/machine-learning/index.html
@@ -180,7 +180,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/project-components/machine-learning/index.html
+++ b/project-components/machine-learning/index.html
@@ -180,7 +180,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/project-components/machine-learning/index.html
+++ b/project-components/machine-learning/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/project-components/machine-learning/index.html
+++ b/project-components/machine-learning/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/project-components/open-data-models/index.html
+++ b/project-components/open-data-models/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/project-components/open-data-models/index.html
+++ b/project-components/open-data-models/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/project-components/open-data-models/index.html
+++ b/project-components/open-data-models/index.html
@@ -187,7 +187,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/project-components/open-data-models/index.html
+++ b/project-components/open-data-models/index.html
@@ -187,7 +187,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/project-components/suspicious-connects-analysis/index.html
+++ b/project-components/suspicious-connects-analysis/index.html
@@ -447,7 +447,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/project-components/suspicious-connects-analysis/index.html
+++ b/project-components/suspicious-connects-analysis/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/project-components/suspicious-connects-analysis/index.html
+++ b/project-components/suspicious-connects-analysis/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/project-components/suspicious-connects-analysis/index.html
+++ b/project-components/suspicious-connects-analysis/index.html
@@ -447,7 +447,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/project-components/visualization/index.html
+++ b/project-components/visualization/index.html
@@ -203,7 +203,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/project-components/visualization/index.html
+++ b/project-components/visualization/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/project-components/visualization/index.html
+++ b/project-components/visualization/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/project-components/visualization/index.html
+++ b/project-components/visualization/index.html
@@ -203,7 +203,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/strength-in-numbers-why-consider-open-source-cybersecurity-analytics/index.html
+++ b/strength-in-numbers-why-consider-open-source-cybersecurity-analytics/index.html
@@ -259,7 +259,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/strength-in-numbers-why-consider-open-source-cybersecurity-analytics/index.html
+++ b/strength-in-numbers-why-consider-open-source-cybersecurity-analytics/index.html
@@ -259,7 +259,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/tag/github/index.html
+++ b/tag/github/index.html
@@ -219,7 +219,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/tag/github/index.html
+++ b/tag/github/index.html
@@ -219,7 +219,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/tag/github/index.html
+++ b/tag/github/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/tag/github/index.html
+++ b/tag/github/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/tag/open-network-insight/index.html
+++ b/tag/open-network-insight/index.html
@@ -219,7 +219,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/tag/open-network-insight/index.html
+++ b/tag/open-network-insight/index.html
@@ -219,7 +219,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/tag/open-network-insight/index.html
+++ b/tag/open-network-insight/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/tag/open-network-insight/index.html
+++ b/tag/open-network-insight/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>

--- a/tag/open-source/index.html
+++ b/tag/open-source/index.html
@@ -219,7 +219,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2018 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/tag/open-source/index.html
+++ b/tag/open-source/index.html
@@ -219,7 +219,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2018 Apache Spot.
                     </p>
 
                 </div>

--- a/tag/open-source/index.html
+++ b/tag/open-source/index.html
@@ -85,7 +85,6 @@
                                 <ul class="sub-menu com-sm">
                                 	<li class="dropmenu-head">Get in Touch</li>
                                 	<li><a href="../../community" class="mail">Mailing Lists</a></li>
-                                	<li><a href="http://slack.apache-spot.io/" target="_blank" class="slack">Slack Channel</a></li>
                                 	<li class="divider"></li>
                                 	<li><a href="../../community/committers">Project Committers</a></li>
                                 	<li><a href="../../community/contribute">How to Contribute</a></li>

--- a/tag/open-source/index.html
+++ b/tag/open-source/index.html
@@ -92,7 +92,7 @@
                                 	<li class="dropmenu-head">Developer Resources</li>
                                 	<li><a href="https://github.com/apache/incubator-spot" target="_blank" class="github">Github</a></li>
                                 	<li><a href="https://issues.apache.org/jira/browse/SPOT/" target="_blank" class="jira">JIRA Issue Tracker</a></li>
-                                	<li class="divider"></li>
+<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=SPOT&title=Apache+Spot+%28Incubating%29+Home" target="_blank" class="">Confluence Site</a></li>                                	<li class="divider"></li>
                                 	<li class="dropmenu-head">Social Media</li>
                                 	<li><a href="https://twitter.com/ApacheSpot" target="_blank" class="twitter-icon">Twitter</a></li>
                                 </ul>


### PR DESCRIPTION
I've made a couple of updates to the Apache Spot Website on the ASF-Site branch.
1) I've removed all references to Slack
2) I've added links to the Confluence website

There's a new folder called "_Tools". It just contains a python script I used to help me perform the updates faster.