### PR TITLE
Spot 297 update remaining website copyright years

### DIFF
--- a/2016/03/index.html
+++ b/2016/03/index.html
@@ -219,7 +219,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/2016/08/index.html
+++ b/2016/08/index.html
@@ -250,7 +250,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/2016/09/index.html
+++ b/2016/09/index.html
@@ -216,7 +216,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/2016/10/index.html
+++ b/2016/10/index.html
@@ -218,7 +218,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/2017/03/index.html
+++ b/2017/03/index.html
@@ -217,7 +217,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/apache-spot-3-most-asked-questions/index.html
+++ b/apache-spot-3-most-asked-questions/index.html
@@ -294,7 +294,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/apache-spot-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
+++ b/apache-spot-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
@@ -299,7 +299,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/apache-spot-3-most-asked-questions/index.html
+++ b/blog/apache-spot-3-most-asked-questions/index.html
@@ -253,7 +253,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/apache-spot-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
+++ b/blog/apache-spot-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
@@ -258,7 +258,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/apache-spot-product-architecture-overview/index.html
+++ b/blog/apache-spot-product-architecture-overview/index.html
@@ -247,7 +247,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/how-apache-spot-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
+++ b/blog/how-apache-spot-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
@@ -240,7 +240,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/index.html
+++ b/blog/index.html
@@ -338,7 +338,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/jupyter-notebooks-for-data-analysis/index.html
+++ b/blog/jupyter-notebooks-for-data-analysis/index.html
@@ -288,7 +288,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/strength-in-numbers-why-consider-open-source-cybersecurity-analytics/index.html
+++ b/blog/strength-in-numbers-why-consider-open-source-cybersecurity-analytics/index.html
@@ -229,7 +229,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/category/cybersecurity/index.html
+++ b/category/cybersecurity/index.html
@@ -218,7 +218,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/category/data-science/index.html
+++ b/category/data-science/index.html
@@ -219,7 +219,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/category/ipython-notebooks/index.html
+++ b/category/ipython-notebooks/index.html
@@ -218,7 +218,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/category/security-analytics/index.html
+++ b/category/security-analytics/index.html
@@ -218,7 +218,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/category/threat-analysis-tools/index.html
+++ b/category/threat-analysis-tools/index.html
@@ -218,7 +218,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/category/uncategorized/index.html
+++ b/category/uncategorized/index.html
@@ -271,7 +271,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/community/committers/index.html
+++ b/community/committers/index.html
@@ -338,7 +338,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -348,7 +348,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/community/committers/index.html
+++ b/community/committers/index.html
@@ -338,7 +338,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2016 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>

--- a/community/contribute/index.html
+++ b/community/contribute/index.html
@@ -265,7 +265,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2016 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>

--- a/community/contribute/index.html
+++ b/community/contribute/index.html
@@ -265,7 +265,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -275,7 +275,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/community/index.html
+++ b/community/index.html
@@ -219,7 +219,7 @@
                 </p>
 
                 <p class="disclaimer">
-                    The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot
+                    The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot
                     and its logo are trademarks of the Apache Software Foundation.
                 </p>
             </div>
@@ -230,7 +230,7 @@
             <div id="inner-footer" class="wrap cf">
 
                 <p class="source-org copyright" style="text-align:center;">
-                    &copy; 2019 Apache Spot.
+                    &copy; 2020 Apache Spot.
                 </p>
 
             </div>

--- a/community/index.html
+++ b/community/index.html
@@ -219,7 +219,7 @@
                 </p>
 
                 <p class="disclaimer">
-                    The contents of this website are © 2016 Apache Software Foundation under the terms of the Apache License v2. Apache Spot
+                    The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot
                     and its logo are trademarks of the Apache Software Foundation.
                 </p>
             </div>

--- a/contribute/index.html
+++ b/contribute/index.html
@@ -196,7 +196,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -206,7 +206,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/contribute/index.html
+++ b/contribute/index.html
@@ -196,7 +196,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2016 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>

--- a/doc/css/style.css
+++ b/doc/css/style.css
@@ -138,7 +138,7 @@ code, kbd, pre, samp { font-family: monospace, serif; font-size: 1em; }
 pre { white-space: pre-wrap; }
 
 /** Set consistent quote types. */
-q { quotes: "\201C" "\201D" "\2018" "\2019"; }
+q { quotes: "\201C" "\201D" "\2018" "\2019" "\2020"; }
 
 /** Address inconsistent and variable font size in all browsers. */
 q:before, q:after { content: ''; content: none; }
@@ -301,7 +301,8 @@ img { max-width: 100%; height: auto; }
 
 .desktop {display:none;}
 
-.orange-bold {color:#c97644;font-weight:bold;font-style:italic;}#configuration .orange-bold {margin-bottom:10px;}
+.orange-bold {color:#c97644;font-weight:bold;font-style:italic;}
+#configuration .orange-bold {margin-bottom:10px;}
 .short-mrg {margin-bottom:10px;}
 
 .slack {
@@ -340,7 +341,7 @@ margin-bottom:25px;
 PUSH MENU
 *********************/
 
-.cbp-spmenu button{position:absolute;top:5px;right:2px;margin:15px 5px 0 0;border:none;background-color:transparent;font-size:2em;color:#fff;text-indent:-999999px;background:url('../images/open.png')no-repeat;width:29px;height:30px;padding:0;}
+.cbp-spmenu button{position:absolute;top:5px;right:2px;margin:15px 5px 0 0;border:none;background-color:transparent;font-size:2em;color:#fff;text-indent:-999999px;background:url('../images/open.png')no-repeat;width:29px;height:30px;padding:0;}
 .cbp-spmenu.cbp-spmenu-open button {background:url('../images/close.png') no-repeat;}
 .cbp-spmenu{background:#d0cbc5;position:absolute;}
 .cbp-spmenu h3{color:#ffffff;font-size:1.9em;padding:20px 0 20px 20px;margin:0 0 15px;font-size:16pt;font-weight:500;text-transform:uppercase;font-family:'Open Sans',sans-serif;letter-spacing:0;}

--- a/doc/index.html
+++ b/doc/index.html
@@ -1304,7 +1304,7 @@
           </p>
 
           <p class="disclaimer">
-            The contents of this website are © 2016 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+            The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
           </p>
         </div>
       </div>
@@ -1314,7 +1314,7 @@
         <div id="inner-footer" class="wrap cf">
 
           <p class="source-org copyright" style="text-align:center;">
-            &copy; 2017 Apache Spot.
+            &copy; 2019 Apache Spot.
           </p>
 
         </div>

--- a/doc/index.html
+++ b/doc/index.html
@@ -1304,7 +1304,7 @@
           </p>
 
           <p class="disclaimer">
-            The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+            The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
           </p>
         </div>
       </div>
@@ -1314,7 +1314,7 @@
         <div id="inner-footer" class="wrap cf">
 
           <p class="source-org copyright" style="text-align:center;">
-            &copy; 2019 Apache Spot.
+            &copy; 2020 Apache Spot.
           </p>
 
         </div>

--- a/download/index.html
+++ b/download/index.html
@@ -205,7 +205,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2016 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>

--- a/download/index.html
+++ b/download/index.html
@@ -205,7 +205,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -215,7 +215,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/get-started/architecture/index.html
+++ b/get-started/architecture/index.html
@@ -154,7 +154,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2016 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>

--- a/get-started/architecture/index.html
+++ b/get-started/architecture/index.html
@@ -154,7 +154,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -164,7 +164,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/get-started/demo/index.html
+++ b/get-started/demo/index.html
@@ -157,7 +157,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -167,7 +167,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/get-started/demo/index.html
+++ b/get-started/demo/index.html
@@ -157,7 +157,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2016 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>

--- a/get-started/environment/index.html
+++ b/get-started/environment/index.html
@@ -162,7 +162,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2016 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>

--- a/get-started/environment/index.html
+++ b/get-started/environment/index.html
@@ -162,7 +162,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -172,7 +172,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/get-started/index.html
+++ b/get-started/index.html
@@ -200,7 +200,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2016 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>

--- a/get-started/index.html
+++ b/get-started/index.html
@@ -200,7 +200,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -210,7 +210,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/get-started/supporting-apache/index.html
+++ b/get-started/supporting-apache/index.html
@@ -195,7 +195,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2016 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>

--- a/get-started/supporting-apache/index.html
+++ b/get-started/supporting-apache/index.html
@@ -195,7 +195,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -205,7 +205,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/how-apache-spot-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
+++ b/how-apache-spot-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
@@ -275,7 +275,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot (Incubating).
+                        &copy; 2020 Apache Spot (Incubating).
                     </p>
 
                 </div>

--- a/how-open-network-insight-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
+++ b/how-open-network-insight-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
@@ -287,7 +287,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot (Incubating).
+                        &copy; 2020 Apache Spot (Incubating).
                     </p>
 
                 </div>

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -4,7 +4,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2016 Apache Spot.
+                        &copy; 2019 Apache Spot.
                     </p>
 
                 </div>

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -4,7 +4,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/includes/prefooter.php
+++ b/includes/prefooter.php
@@ -16,7 +16,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>

--- a/includes/prefooter.php
+++ b/includes/prefooter.php
@@ -16,7 +16,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2016 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -421,7 +421,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -431,7 +431,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/index.html
+++ b/index.html
@@ -421,7 +421,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2016 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>

--- a/jupyter-notebooks-for-data-analysis/index.html
+++ b/jupyter-notebooks-for-data-analysis/index.html
@@ -314,7 +314,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot (Incubating).
+                        &copy; 2020 Apache Spot (Incubating).
                     </p>
 
                 </div>

--- a/library/css/style.css
+++ b/library/css/style.css
@@ -145,7 +145,7 @@ code, kbd, pre, samp { font-family: monospace, serif; font-size: 1em; }
 pre { white-space: pre-wrap; }
 
 /** Set consistent quote types. */
-q { quotes: "\201C" "\201D" "\2018" "\2019"; }
+q { quotes: "\201C" "\201D" "\2018" "\2019" "\2020"; }
 
 /** Address inconsistent and variable font size in all browsers. */
 q:before, q:after { content: ''; content: none; }
@@ -1182,7 +1182,8 @@ you can add resource intensive styles.
   #use-case .table:last-of-type { padding-bottom: 0; }
   #use-case .left img { margin-bottom: 0; padding-right: 25px; }
   #use-case h3 {margin: 0 0 15px;text-align:left;}
-  .quotes .table-cell {display:table-cell;text-align:left;}  .table-cell.quote-man {padding-right:35px;text-align:center;}
+  .quotes .table-cell {display:table-cell;text-align:left;}
+  .table-cell.quote-man {padding-right:35px;text-align:center;}
   .table-cell.quote-man img {text-align:center;}
   .arrow { height: 80px; }
   .arrow p { margin: 20px 85px 20px 25px; }

--- a/open-network-insight-3-most-asked-questions/index.html
+++ b/open-network-insight-3-most-asked-questions/index.html
@@ -300,7 +300,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/open-network-insight-oni-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
+++ b/open-network-insight-oni-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
@@ -305,7 +305,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/project-components/ingestion/index.html
+++ b/project-components/ingestion/index.html
@@ -194,7 +194,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2016 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>

--- a/project-components/ingestion/index.html
+++ b/project-components/ingestion/index.html
@@ -194,7 +194,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -204,7 +204,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/project-components/machine-learning/index.html
+++ b/project-components/machine-learning/index.html
@@ -170,7 +170,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -180,7 +180,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/project-components/machine-learning/index.html
+++ b/project-components/machine-learning/index.html
@@ -170,7 +170,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2016 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>

--- a/project-components/open-data-models/index.html
+++ b/project-components/open-data-models/index.html
@@ -177,7 +177,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2016 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>

--- a/project-components/open-data-models/index.html
+++ b/project-components/open-data-models/index.html
@@ -177,7 +177,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -187,7 +187,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/project-components/suspicious-connects-analysis/index.html
+++ b/project-components/suspicious-connects-analysis/index.html
@@ -437,7 +437,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2016 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>

--- a/project-components/suspicious-connects-analysis/index.html
+++ b/project-components/suspicious-connects-analysis/index.html
@@ -437,7 +437,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -447,7 +447,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/project-components/visualization/index.html
+++ b/project-components/visualization/index.html
@@ -193,7 +193,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2016 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>

--- a/project-components/visualization/index.html
+++ b/project-components/visualization/index.html
@@ -193,7 +193,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2019 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -203,7 +203,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/strength-in-numbers-why-consider-open-source-cybersecurity-analytics/index.html
+++ b/strength-in-numbers-why-consider-open-source-cybersecurity-analytics/index.html
@@ -259,7 +259,7 @@
 
                     <nav role="navigation"></nav>
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/tag/github/index.html
+++ b/tag/github/index.html
@@ -219,7 +219,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/tag/open-network-insight/index.html
+++ b/tag/open-network-insight/index.html
@@ -219,7 +219,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/tag/open-source/index.html
+++ b/tag/open-source/index.html
@@ -219,7 +219,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2019 Apache Spot.
+                        &copy; 2020 Apache Spot.
                     </p>
 
                 </div>

--- a/wp-content/themes/oni/library/css/style.css
+++ b/wp-content/themes/oni/library/css/style.css
@@ -118,7 +118,7 @@ code, kbd, pre, samp { font-family: monospace, serif; font-size: 1em; }
 pre { white-space: pre-wrap; }
 
 /** Set consistent quote types. */
-q { quotes: "\201C" "\201D" "\2018" "\2019"; }
+q { quotes: "\201C" "\201D" "\2018" "\2019" "\2020"; }
 
 /** Address inconsistent and variable font size in all browsers. */
 q:before, q:after { content: ''; content: none; }


### PR DESCRIPTION
Resolves [SPOT-297](https://issues.apache.org/jira/browse/SPOT-297).  The root index.html and a few other files still had a 2016 reference, and the 2019 references also needed updating to 2020.