### PR TITLE
Spot 296 update copyright year in master

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -271,7 +271,7 @@ SOFTWARE.
 For D3's World 110m  (spot-oa/ui/flow/world-110m.json):
 ========================================================================
 
-Copyright (c) 2014-2019, Michael Bostock
+Copyright (c) 2014-2020, Michael Bostock
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/LICENSE
+++ b/LICENSE
@@ -271,7 +271,7 @@ SOFTWARE.
 For D3's World 110m  (spot-oa/ui/flow/world-110m.json):
 ========================================================================
 
-Copyright (c) 2014, Michael Bostock
+Copyright (c) 2014-2019, Michael Bostock
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Spot
-Copyright 2017 The Apache Software Foundation
+Copyright 2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Spot
-Copyright 2019 The Apache Software Foundation
+Copyright 2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
Resolves [SPOT-296](https://issues.apache.org/jira/browse/SPOT-296).  There were some dependency copyrights in the LICENSE file that needed updating to 2020 as well as the NOTICE file.