### PR TITLE
Spot 304 fix inconsistencies between hive and avro

### DIFF
--- a/spot-ingest/pipelines/flow/load_flow_avro_parquet.hql
+++ b/spot-ingest/pipelines/flow/load_flow_avro_parquet.hql
@@ -79,7 +79,7 @@ TBLPROPERTIES ('avro.schema.literal'='{
      ,  {"name": "fwd",                 "type":["int",   "null"]}
      ,  {"name": "stos",                 "type":["int",   "null"]}
      ,  {"name": "ipkt",                 "type":["bigint",   "null"]}
-     ,  {"name": "ibytt",                 "type":["bigint",   "null"]}
+     ,  {"name": "ibyt",                 "type":["bigint",   "null"]}
      ,  {"name": "opkt",                 "type":["bigint",   "null"]}
      ,  {"name": "obyt",                 "type":["bigint",   "null"]}
      ,  {"name": "input",                 "type":["int",   "null"]}

--- a/spot-ingest/pipelines/flow/worker.py
+++ b/spot-ingest/pipelines/flow/worker.py
@@ -188,7 +188,7 @@ class Worker(object):
                            "      ,  {{\"name\": \"fwd\",                   \"type\":[\"int\",   \"null\"]}}\n"
                            "      ,  {{\"name\": \"stos\",                  \"type\":[\"int\",   \"null\"]}}\n"
                            "      ,  {{\"name\": \"ipkt\",               \"type\":[\"bigint\",   \"null\"]}}\n"
-                           "      ,  {{\"name\": \"ibytt\",              \"type\":[\"bigint\",   \"null\"]}}\n"
+                           "      ,  {{\"name\": \"ibyt\",              \"type\":[\"bigint\",   \"null\"]}}\n"
                            "      ,  {{\"name\": \"opkt\",               \"type\":[\"bigint\",   \"null\"]}}\n"
                            "      ,  {{\"name\": \"obyt\",               \"type\":[\"bigint\",   \"null\"]}}\n"
                            "      ,  {{\"name\": \"input\",                 \"type\":[\"int\",   \"null\"]}}\n"


### PR DESCRIPTION
In two instances, Avro files are created with internal schema where one of the fields "ibyt" was mis-spelled "ibytt".  This corrects that.