### PR TITLE
Add SSL argument to Impala shell

### DIFF
--- a/spot-setup/hdfs_setup.sh
+++ b/spot-setup/hdfs_setup.sh
@@ -124,6 +124,9 @@ case ${DBENGINE} in
         if [[ ${KERBEROS} == "true" ]]; then
             db_shell="${db_shell} -k"
         fi
+        if [[ ${SSL} == "true" ]]; then
+            db_shell="${db_shell} --ssl"
+        fi
         db_query="${db_shell} -q"
         db_script="${db_shell} --var=huser=${HUSER} --var=dbname=${DBNAME} -c -f"
         ;;


### PR DESCRIPTION
Resolves SPOT-308.  This just appends ssl on the end of the impala shell command.  This runs without the ca_cert argument, which I think should be fine in most cases.

I didn't update beeline since the spot.conf sort of implies that the JDBC connection string should include kerberos and ssl arguments before hand.  I also ignored the Hive shell, but we should just think about deprecating that whole piece of the code anyway since beeline is more widely supported to connect to Hive.

We should also probably revisit just rewriting this whole thing as a python interface at some point so that we're not maintaining so many versions of the same commands, ddls, etc.