### PR TITLE
SPOT-299 Asf site whimsy fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,6 +113,17 @@
                             <li id="menu-item-13" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-13">
                                 <a href="blog">Blog</a>
                             </li>
+                            <li id="menu-item-999" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-130">
+                                <a href="get-started/supporting-apache" data-toggle="dropdown" class="dropdown-toggle">Apache<b class="caret"></b></a>
+                                <ul class="sub-menu">
+                                    <li><a href="http://www.apache.org/foundation/how-it-works.html" target="_blank">Apache Software Foundation</a></li>
+                                    <li><a href="http://www.apache.org/events/current-event" target="_blank">Apache Events</a></li>
+                                    <li><a href="http://www.apache.org/licenses/" target="_blank">License</a></li>
+                                    <li><a href="http://www.apache.org/foundation/thanks.html" target="_blank">Thanks</a></li>
+                                    <li><a href="http://www.apache.org/security/" target="_blank">Security</a></li>
+                                    <li><a href="http://www.apache.org/foundation/sponsorship" target="_blank">Sponsorship</a></li>
+                                </ul>
+                            </li>
                         </ul>
                     </nav>
 


### PR DESCRIPTION
In SPOT-299, we were trying to add the required ASF site to the home page.  However, after we reviewed the Whimsy logs, it is not enough for links to be available on the home page, the html must actually regex the links.  After reviewing other ASF projects, we found out that Livy had a drop-down menu like ours, that was easily adapted to our needs.  Thus, this change fulfills the intention of SPOT-299 and complies with ASF regulations.
