### PR TITLE
Update website copyrights and scanning config

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,5 @@
+publish:
+  whoami: asf-site
+
+staging:
+  whoami: asf-staging

--- a/blog/apache-spot-3-most-asked-questions/index.html
+++ b/blog/apache-spot-3-most-asked-questions/index.html
@@ -225,7 +225,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2020 Apache Spot.
+                        &copy; 2021 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/apache-spot-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
+++ b/blog/apache-spot-and-cybersecurity-using-netflows-to-detect-threats-to-critical-infrastructure/index.html
@@ -231,7 +231,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2020 Apache Spot.
+                        &copy; 2021 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/apache-spot-product-architecture-overview/index.html
+++ b/blog/apache-spot-product-architecture-overview/index.html
@@ -221,7 +221,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2020 Apache Spot.
+                        &copy; 2021 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/how-apache-spot-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
+++ b/blog/how-apache-spot-helps-create-well-stocked-data-lakes-and-catch-powerful-insights/index.html
@@ -214,7 +214,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2020 Apache Spot.
+                        &copy; 2021 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/index.html
+++ b/blog/index.html
@@ -317,7 +317,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2020 Apache Spot.
+                        &copy; 2021 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/jupyter-notebooks-for-data-analysis/index.html
+++ b/blog/jupyter-notebooks-for-data-analysis/index.html
@@ -261,7 +261,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2020 Apache Spot.
+                        &copy; 2021 Apache Spot.
                     </p>
 
                 </div>

--- a/blog/strength-in-numbers-why-consider-open-source-cybersecurity-analytics/index.html
+++ b/blog/strength-in-numbers-why-consider-open-source-cybersecurity-analytics/index.html
@@ -203,7 +203,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2020 Apache Spot.
+                        &copy; 2021 Apache Spot.
                     </p>
 
                 </div>

--- a/community/committers/index.html
+++ b/community/committers/index.html
@@ -337,7 +337,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2021 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -347,7 +347,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2020 Apache Spot.
+                        &copy; 2021 Apache Spot.
                     </p>
 
                 </div>

--- a/community/contribute/index.html
+++ b/community/contribute/index.html
@@ -264,7 +264,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2021 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -274,7 +274,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2020 Apache Spot.
+                        &copy; 2021 Apache Spot.
                     </p>
 
                 </div>

--- a/community/index.html
+++ b/community/index.html
@@ -218,7 +218,7 @@
                 </p>
 
                 <p class="disclaimer">
-                    The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot
+                    The contents of this website are © 2021 Apache Software Foundation under the terms of the Apache License v2. Apache Spot
                     and its logo are trademarks of the Apache Software Foundation.
                 </p>
             </div>
@@ -229,7 +229,7 @@
             <div id="inner-footer" class="wrap cf">
 
                 <p class="source-org copyright" style="text-align:center;">
-                    &copy; 2020 Apache Spot.
+                    &copy; 2021 Apache Spot.
                 </p>
 
             </div>

--- a/contribute/index.html
+++ b/contribute/index.html
@@ -195,7 +195,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2021 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -205,7 +205,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2020 Apache Spot.
+                        &copy; 2021 Apache Spot.
                     </p>
 
                 </div>

--- a/doc/css/style.css
+++ b/doc/css/style.css
@@ -138,7 +138,7 @@ code, kbd, pre, samp { font-family: monospace, serif; font-size: 1em; }
 pre { white-space: pre-wrap; }
 
 /** Set consistent quote types. */
-q { quotes: "\201C" "\201D" "\2018" "\2019" "\2020"; }
+q { quotes: "\201C" "\201D" "\2018" "\2019" "\2020" "\2021"; }
 
 /** Address inconsistent and variable font size in all browsers. */
 q:before, q:after { content: ''; content: none; }

--- a/doc/index.html
+++ b/doc/index.html
@@ -1322,7 +1322,7 @@
           </p>
 
           <p class="disclaimer">
-            The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+            The contents of this website are © 2021 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
           </p>
         </div>
       </div>
@@ -1332,7 +1332,7 @@
         <div id="inner-footer" class="wrap cf">
 
           <p class="source-org copyright" style="text-align:center;">
-            &copy; 2020 Apache Spot.
+            &copy; 2021 Apache Spot.
           </p>
 
         </div>

--- a/download/index.html
+++ b/download/index.html
@@ -204,7 +204,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2021 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -214,7 +214,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2020 Apache Spot.
+                        &copy; 2021 Apache Spot.
                     </p>
 
                 </div>

--- a/get-started/architecture/index.html
+++ b/get-started/architecture/index.html
@@ -153,7 +153,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2021 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -163,7 +163,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2020 Apache Spot.
+                        &copy; 2021 Apache Spot.
                     </p>
 
                 </div>

--- a/get-started/demo/index.html
+++ b/get-started/demo/index.html
@@ -156,7 +156,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2021 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -166,7 +166,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2020 Apache Spot.
+                        &copy; 2021 Apache Spot.
                     </p>
 
                 </div>

--- a/get-started/environment/index.html
+++ b/get-started/environment/index.html
@@ -161,7 +161,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2021 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -171,7 +171,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2020 Apache Spot.
+                        &copy; 2021 Apache Spot.
                     </p>
 
                 </div>

--- a/get-started/index.html
+++ b/get-started/index.html
@@ -199,7 +199,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2021 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -209,7 +209,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2020 Apache Spot.
+                        &copy; 2021 Apache Spot.
                     </p>
 
                 </div>

--- a/get-started/supporting-apache/index.html
+++ b/get-started/supporting-apache/index.html
@@ -203,7 +203,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2021 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -213,7 +213,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2020 Apache Spot.
+                        &copy; 2021 Apache Spot.
                     </p>
 
                 </div>

--- a/index.html
+++ b/index.html
@@ -431,7 +431,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2021 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -441,7 +441,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2020 Apache Spot.
+                        &copy; 2021 Apache Spot.
                     </p>
 
                 </div>

--- a/library/css/style.css
+++ b/library/css/style.css
@@ -145,7 +145,7 @@ code, kbd, pre, samp { font-family: monospace, serif; font-size: 1em; }
 pre { white-space: pre-wrap; }
 
 /** Set consistent quote types. */
-q { quotes: "\201C" "\201D" "\2018" "\2019" "\2020"; }
+q { quotes: "\201C" "\201D" "\2018" "\2019" "\2020" "\2021"; }
 
 /** Address inconsistent and variable font size in all browsers. */
 q:before, q:after { content: ''; content: none; }

--- a/project-components/ingestion/index.html
+++ b/project-components/ingestion/index.html
@@ -193,7 +193,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2021 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -203,7 +203,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2020 Apache Spot.
+                        &copy; 2021 Apache Spot.
                     </p>
 
                 </div>

--- a/project-components/machine-learning/index.html
+++ b/project-components/machine-learning/index.html
@@ -169,7 +169,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2021 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -179,7 +179,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2020 Apache Spot.
+                        &copy; 2021 Apache Spot.
                     </p>
 
                 </div>

--- a/project-components/open-data-models/index.html
+++ b/project-components/open-data-models/index.html
@@ -3343,7 +3343,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2021 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -3353,7 +3353,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2020 Apache Spot.
+                        &copy; 2021 Apache Spot.
                     </p>
 
                 </div>

--- a/project-components/suspicious-connects-analysis/index.html
+++ b/project-components/suspicious-connects-analysis/index.html
@@ -436,7 +436,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2021 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -446,7 +446,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2020 Apache Spot.
+                        &copy; 2021 Apache Spot.
                     </p>
 
                 </div>

--- a/project-components/visualization/index.html
+++ b/project-components/visualization/index.html
@@ -192,7 +192,7 @@
                     </p>
 
                     <p class="disclaimer">
-                        The contents of this website are © 2020 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
+                        The contents of this website are © 2021 Apache Software Foundation under the terms of the Apache License v2. Apache Spot and its logo are trademarks of the Apache Software Foundation.
                     </p>
                 </div>
             </div>
@@ -202,7 +202,7 @@
                 <div id="inner-footer" class="wrap cf">
 
                     <p class="source-org copyright" style="text-align:center;">
-                        &copy; 2020 Apache Spot.
+                        &copy; 2021 Apache Spot.
                     </p>
 
                 </div>


### PR DESCRIPTION
- Updated all 2020 copyrights to 2021
- Added the .asf.yaml file so that our website publishing works properly again (https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-WebSiteDeploymentServiceforGitRepositories)

We should also look at creating an asf-staging branch we can make changes on first and validate before we publish to asf-site. 